### PR TITLE
agm: properly typecast return values and update function signatures

### DIFF
--- a/plugins/tinyalsa/src/agm_mixer_plugin.c
+++ b/plugins/tinyalsa/src/agm_mixer_plugin.c
@@ -2244,7 +2244,7 @@ static int amp_form_acdb_ctls(struct amp_priv *amp_priv, int ctl_idx)
 }
 
 static ssize_t amp_read_event(struct mixer_plugin *plugin,
-                              struct mixer_ctl_event *ev, size_t size) 
+                              struct snd_ctl_event *ev, long unsigned size)
 {
     struct amp_priv *amp_priv = plugin->priv;
     ssize_t result = 0;

--- a/plugins/tinyalsa/src/agm_pcm_plugin.c
+++ b/plugins/tinyalsa/src/agm_pcm_plugin.c
@@ -882,21 +882,15 @@ static int agm_pcm_munmap(struct pcm_plugin *plugin, void *addr, size_t length)
     return munmap(addr, length);
 }
 
-static int agm_pcm_ioctl(struct pcm_plugin *plugin, int cmd, ...)
+static int agm_pcm_ioctl(struct pcm_plugin *plugin, int cmd, void *arg)
 {
     struct agm_pcm_priv *priv = plugin->priv;
     uint64_t handle;
     int ret = 0;
-    va_list ap;
-    void *arg;
 
     ret = agm_get_session_handle(priv, &handle);
     if (ret)
         return ret;
-
-    va_start(ap, cmd);
-    arg = va_arg(ap, void *);
-    va_end(ap);
 
     switch (cmd) {
     case SNDRV_PCM_IOCTL_RESET:
@@ -981,7 +975,7 @@ int agm_pcm_open(struct pcm_plugin **plugin, unsigned int card,
     priv->dev_node = pcm_node;
     priv->session_id = session_id;
     priv->mmap_status = false;
-    snd_card_def_get_int(pcm_node, "session_mode", &sess_mode);
+    snd_card_def_get_int(pcm_node, "session_mode", (int *) &sess_mode);
 
     ret = agm_session_open(session_id, sess_mode, &handle);
     if (ret) {

--- a/plugins/tinyalsa/test/Makefile.am
+++ b/plugins/tinyalsa/test/Makefile.am
@@ -3,7 +3,7 @@ pkgconfig_DATA = agmtest.pc
 EXTRA_DIST = $(pkgconfig_DATA)
 
 AM_CFLAGS = -Wno-unused-parameter -Wno-unused-result
-AM_CFLAGS += -I${includedir}/acdbdata -I$(top_srcdir)/service/inc/public
+AM_CFLAGS += -I$(top_srcdir)/service/inc/public
 AM_CFLAGS += $(GLIB_CFLAGS) -include glib.h @KVH2XML_CFLAGS@
 
 if USE_G_STR_FUNC

--- a/service/inc/private/agm/agm_priv.h
+++ b/service/inc/private/agm/agm_priv.h
@@ -36,7 +36,7 @@
  * Key Vector
  */
 struct agm_key_vector_gsl {
-    size_t num_kvs;                 /**< number of key value pairs */
+    uint32_t num_kvs;               /**< number of key value pairs */
     struct agm_key_value *kv;       /**< array of key value pairs */
 };
 struct sg_prop {

--- a/service/src/agm.c
+++ b/service/src/agm.c
@@ -323,18 +323,18 @@ int agm_get_params_from_acdb_tunnel(void *payload, size_t *size)
         payloadACDBTunnelInfo->num_kvs,
         payloadACDBTunnelInfo->blob_size);
 
-    ptr = payloadACDBTunnelInfo->blob;
+    ptr = (uint32_t *) payloadACDBTunnelInfo->blob;
     for (k = 0; k < payloadACDBTunnelInfo->blob_size / 4; k++) {
         AGM_LOGV("%d data = 0x%x", k, *ptr++);
     }
 
-    ptr = payloadACDBTunnelInfo->blob + sizeof(struct agm_key_value) *
+    ptr = (uint32_t *) payloadACDBTunnelInfo->blob + sizeof(struct agm_key_value) *
             (payloadACDBTunnelInfo->num_gkvs + payloadACDBTunnelInfo->num_kvs);
     // tag is stored at miid. Convertion happens next.
     AGM_LOGI("tag = 0x%x", *ptr);
 
     gkv.num_kvs = payloadACDBTunnelInfo->num_gkvs;
-    gkv.kv = payloadACDBTunnelInfo->blob;
+    gkv.kv = (struct agm_key_value *) payloadACDBTunnelInfo->blob;
 
     ret = session_dummy_rw_acdb_tunnel(payload, FALSE);
     if (ret) {
@@ -544,12 +544,12 @@ int agm_set_params_to_acdb_tunnel(void *payload, size_t size)
         payloadACDBTunnelInfo->num_kvs,
         payloadACDBTunnelInfo->blob_size);
 
-    ptr = payloadACDBTunnelInfo->blob;
+    ptr = (uint32_t *) payloadACDBTunnelInfo->blob;
     for (k = 0; k < payloadACDBTunnelInfo->blob_size / 4; k++) {
         AGM_LOGV("%d data = 0x%x", k, *ptr++);
     }
 
-    ptr = payloadACDBTunnelInfo->blob + sizeof(struct agm_key_value) *
+    ptr = (uint32_t *) payloadACDBTunnelInfo->blob + sizeof(struct agm_key_value) *
             (payloadACDBTunnelInfo->num_gkvs + payloadACDBTunnelInfo->num_kvs);
     // tag is stored at miid. Convertion happens next.
     AGM_LOGI("tag = 0x%x", *ptr);

--- a/service/src/graph.c
+++ b/service/src/graph.c
@@ -1240,30 +1240,30 @@ int graph_rw_acdb_param(void *payload, bool is_param_write)
         payloadACDBTunnelInfo->num_kvs,
         payloadACDBTunnelInfo->blob_size);
 
-    ptr = payloadACDBTunnelInfo->blob;
+    ptr = (uint32_t *) payloadACDBTunnelInfo->blob;
     for (i = 0; i < payloadACDBTunnelInfo->blob_size / 4; i++) {
         AGM_LOGV("%d data = 0x%x", i, *ptr++);
     }
 
-    ptr = payloadACDBTunnelInfo->blob + sizeof(struct agm_key_value) *
+    ptr = (uint32_t *) payloadACDBTunnelInfo->blob + sizeof(struct agm_key_value) *
             (payloadACDBTunnelInfo->num_gkvs + payloadACDBTunnelInfo->num_kvs);
     header = (struct apm_module_param_data_t *)ptr;
-    ptr_to_param = header;
+    ptr_to_param = (uint8_t *) header;
 
     // tag is stored at miid. Convertion happens next.
     tag = *ptr;
     AGM_LOGD("tag to be translated is 0x%x", tag);
 
     gkv.num_kvs = payloadACDBTunnelInfo->num_gkvs;
-    gkv.kv = payloadACDBTunnelInfo->blob;
+    gkv.kv = (struct agm_key_value *) payloadACDBTunnelInfo->blob;
 
-    ret = gsl_get_tags_with_module_info(&gkv, NULL, &size);
+    ret = gsl_get_tags_with_module_info((const struct gsl_key_vector *) &gkv, NULL, &size);
     if (ret) {
         AGM_LOGE("failed to get tag info size = %d size=0x%x", ret, size);
         return ret;
     }
 
-    ret = gsl_get_tags_with_module_info(&gkv, tag_pool, &size);
+    ret = gsl_get_tags_with_module_info((const struct gsl_key_vector *) &gkv, tag_pool, &size);
     if (ret) {
         AGM_LOGE("failed to get tag pool ret = %d size=0x%x", ret, size);
         return ret;
@@ -1300,7 +1300,7 @@ int graph_rw_acdb_param(void *payload, bool is_param_write)
     header->module_instance_id = miid;
     AGM_LOGI("translated miid is = 0x%x", header->module_instance_id);
     kv.num_kvs = payloadACDBTunnelInfo->num_kvs;
-    kv.kv = payloadACDBTunnelInfo->blob +
+    kv.kv = (struct agm_key_value *) payloadACDBTunnelInfo->blob +
         payloadACDBTunnelInfo->num_gkvs * sizeof(struct agm_key_value);
 
     AGM_LOGD("blob size = %d", payloadACDBTunnelInfo->blob_size);
@@ -1310,7 +1310,7 @@ int graph_rw_acdb_param(void *payload, bool is_param_write)
     __builtin_sub_overflow(payloadACDBTunnelInfo->blob_size, temp_sum, &actual_size);
     AGM_LOGD("actual size = 0x%x", actual_size);
     AGM_LOGI("num kvs = %d", kv.num_kvs);
-    ptr = kv.kv;
+    ptr = (uint32_t *) kv.kv;
     for (i = 0; i < kv.num_kvs; i++) {
         AGM_LOGI("kv %d %x", i, *ptr++);
         AGM_LOGI("kv %d %x", i, *ptr++);
@@ -1331,19 +1331,22 @@ int graph_rw_acdb_param(void *payload, bool is_param_write)
             total_parsed_size, header->param_size, offset);
     }
 
-    ptr = ptr_to_param;
+    ptr = (uint32_t *) ptr_to_param;
     for (i = 0; i < actual_size / 4; i++) {
         AGM_LOGV("%d data to acdb = 0x%x", i, *ptr++);
     }
 
     if (is_param_write) {
         if (payloadACDBTunnelInfo->isTKV)
-            ret = gsl_set_tag_data_to_acdb(&gkv, tag, &kv, ptr_to_param, actual_size);
+            ret = gsl_set_tag_data_to_acdb((const struct gsl_key_vector *) &gkv,
+                    tag, (const struct gsl_key_vector *) &kv, ptr_to_param, actual_size);
         else
-            ret = gsl_set_cal_data_to_acdb(&gkv, &kv, ptr_to_param, actual_size);
+            ret = gsl_set_cal_data_to_acdb((const struct gsl_key_vector *) &gkv,
+                    (const struct gsl_key_vector *) &kv, ptr_to_param, actual_size);
     } else {
         if (payloadACDBTunnelInfo->isTKV)
-            ret = graph_get_tckv_data_from_acdb(&gkv, tag, &kv, ptr_to_param, &actual_size);
+            ret = graph_get_tckv_data_from_acdb((const struct agm_key_vector_gsl *) &gkv,
+                    tag, (const struct agm_key_vector_gsl *) &kv, ptr_to_param, &actual_size);
         else
             ret = graph_get_tckv_data_from_acdb(&gkv, 0, &kv, ptr_to_param, &actual_size);
     }
@@ -2223,13 +2226,13 @@ int graph_get_tckv_data_from_acdb(
     if (tag) {
         AGM_LOGI("Tag for tkv is 0x%x", tag);
         ret = gsl_get_tag_data_from_acdb((struct gsl_key_vector *)graph_key_vect,
-                    tag, (struct gsl_key_vector *)tag_key_vect, 1, param_list,
-                    NULL, payload_size);
+                    tag, (struct gsl_key_vector *)tag_key_vect, 1, (uint8_t *)param_list,
+                    NULL, (uint32_t *) payload_size);
     } else {
         AGM_LOGI("This is ckv");
         ret = gsl_get_cal_data_from_acdb((struct gsl_key_vector *)graph_key_vect,
-                    (struct gsl_key_vector *)tag_key_vect, 1, param_list,
-                    NULL, payload_size);
+                    (struct gsl_key_vector *)tag_key_vect, 1, (uint8_t *) param_list,
+                    NULL, (uint32_t *) payload_size);
     }
 
     if (ret) {
@@ -2255,13 +2258,13 @@ int graph_get_tckv_data_from_acdb(
     if (tag) {
         AGM_LOGE("This is tag data.");
         ret = gsl_get_tag_data_from_acdb((struct gsl_key_vector *)graph_key_vect,
-                    tag, (struct gsl_key_vector *)tag_key_vect, 1, param_list,
-                    get_payload, payload_size);
+                    tag, (struct gsl_key_vector *)tag_key_vect, 1, (uint8_t *) param_list,
+                    get_payload, (uint32_t *) payload_size);
     } else {
         AGM_LOGE("This is ckv data.");
         ret = gsl_get_cal_data_from_acdb((struct gsl_key_vector *)graph_key_vect,
-                    (struct gsl_key_vector *)tag_key_vect, 1, param_list,
-                    get_payload, payload_size);
+                    (struct gsl_key_vector *)tag_key_vect, 1, (uint8_t *) param_list,
+                    get_payload, (uint32_t *) payload_size);
     }
 
     if (ret) {
@@ -2342,7 +2345,8 @@ static void print_graph_alias(const struct agm_meta_data_gsl *meta_data_kv)
         return;
     }
 
-    ret = gsl_get_graph_alias(&meta_data_kv->gkv, acdb_string, &acdb_string_len);
+    ret = gsl_get_graph_alias((const struct gsl_key_vector *) &meta_data_kv->gkv,
+            acdb_string, &acdb_string_len);
     if (ret) {
         AGM_LOGD("gsl_get_graph_alias failed: ret = %d\n", ret);
         return;


### PR DESCRIPTION
Corrected type definitions and function signatures to avoid type mismatch warnings.
Makefile remove redundant include path.
Avoid type mismatch warnings (treated as errors) when compiling with GCC 14.2.