### PR TITLE
AGM: Make SPR position reset as non-fatal for use case.

### DIFF
--- a/service/src/graph_module.c
+++ b/service/src/graph_module.c
@@ -2089,7 +2089,11 @@ int configure_spr_session_time_reset_info(struct module_info* spr_mod,
     if (ret != 0) {
         ret = ar_err_get_lnx_err_code(ret);
         AGM_LOGE("failed for PARAM_ID_SPR_SESSION_TIME_RESET_INFO: %d", ret);
-        return ret;
+
+        /* To make backward compatibility with ADSP where latest SPR module */
+        /* configuration is not supported and to avoid failing use case     */
+        /* error is not being propagated                                    */
+        return 0;
     }
 
     AGM_LOGD("configured");


### PR DESCRIPTION
If ADSP is not compatible with SPR latest module configuration, SPR module configuration of reset info would fail, instead of failing use case, log the error and continue.
such that basic use case functionality is not affected.

The effect of SPR reset failure would have effect only in case of gapless scenarios.