### PR TITLE
tinyalsa/test: clean up agmmixer API and fix issues

### DIFF
--- a/plugins/tinyalsa/test/agmcap.c
+++ b/plugins/tinyalsa/test/agmcap.c
@@ -81,7 +81,7 @@ static void sigint_handler(int sig)
     capturing = 0;
 }
 
-static void usage(void)
+static void usage(char *progname)
 {
     printf(" Usage: %s file.wav [-help print usage] [-D card] [-d device]\n"
            " [-c channels] [-r rate] [-b bits] [-p period_size]\n"
@@ -92,7 +92,7 @@ static void usage(void)
            " [-is_24_LE] : [0-1] Only to be used if user wants to record 32 bps clip\n"
            " [-usb_d usb device]\n"
            " 0: If bps is 32, and format should be S32_LE\n"
-           " 1: If bps is 24, and format should be S24_LE\n");
+           " 1: If bps is 24, and format should be S24_LE\n", progname);
 }
 
 int main(int argc, char **argv)
@@ -120,7 +120,7 @@ int main(int argc, char **argv)
     bool is_24_LE = false;
 
     if (argc < 2) {
-        usage();
+        usage(argv[0]);
         return 1;
     }
 
@@ -194,7 +194,7 @@ int main(int argc, char **argv)
             if (*argv)
                 usb_device = atoi(*argv);
         }else if (strcmp(*argv, "-help") == 0) {
-            usage();
+            usage(argv[0]);
         }
         if (*argv)
             argv++;
@@ -359,8 +359,8 @@ unsigned int capture_sample(FILE *file, unsigned int card, unsigned int device,
     if (ret) {
         printf("MFC not present for this graph\n");
     } else {
-        if (configure_mfc(mixer, device, intf_name, TAG_STREAM_MFC,
-                     STREAM_PCM, rate, channels, get_tinyalsa_pcm_bit_width(format), miid)) {
+        if (configure_mfc(mixer, device, STREAM_PCM, rate, channels, 
+                          get_tinyalsa_pcm_bit_width(format), miid)) {
             printf("Failed to configure stream mfc\n");
             goto err_close_mixer;
         }

--- a/plugins/tinyalsa/test/agmcompresscap.c
+++ b/plugins/tinyalsa/test/agmcompresscap.c
@@ -351,8 +351,8 @@ static void capture_samples(char *name, unsigned int card, unsigned int device,
     if (ret) {
         printf("MFC not present for this graph");
     } else {
-        if (configure_mfc(mixer, device, intf_name, TAG_STREAM_MFC,
-                     STREAM_COMPRESS, rate, channels, pcm_format_to_bits(format), miid)) {
+        if (configure_mfc(mixer, device, STREAM_COMPRESS, rate, channels, 
+            pcm_format_to_bits(format), miid)) {
             printf("Failed to configure pspd mfc\n");
             goto mixer_exit;
         }

--- a/plugins/tinyalsa/test/agmcompressplay.c
+++ b/plugins/tinyalsa/test/agmcompressplay.c
@@ -527,9 +527,8 @@ void play_samples(char *name, unsigned int card, unsigned int device, unsigned i
         if (ret) {
             printf("MFC not present for this graph\n");
         } else {
-            if (configure_mfc(mixer, device, intf_name[index], PER_STREAM_PER_DEVICE_MFC,
-                           STREAM_COMPRESS, dev_config[index].rate, dev_config[index].ch,
-                           dev_config[index].bits, miid)) {
+            if (configure_mfc(mixer, device, STREAM_COMPRESS, dev_config[index].rate, 
+                dev_config[index].ch, dev_config[index].bits, miid)) {
                 printf("Failed to configure pspd mfc\n");
                 goto MIXER_EXIT;
             }

--- a/plugins/tinyalsa/test/agmhostless.c
+++ b/plugins/tinyalsa/test/agmhostless.c
@@ -303,9 +303,8 @@ void play_loopback(unsigned int card, unsigned int p_device, unsigned int c_devi
     if (ret) {
         printf("MFC not present for this graph\n");
     } else {
-        if (configure_mfc(mixer, p_device, p_intf_name, PER_STREAM_PER_DEVICE_MFC,
-                           STREAM_PCM, p_config->rate, p_config->ch,
-                           p_config->bits, miid)) {
+        if (configure_mfc(mixer, p_device, STREAM_PCM, p_config->rate, 
+            p_config->ch, p_config->bits, miid)) {
             printf("Failed to configure pspd mfc\n");
             goto err_disconnect;
         }

--- a/plugins/tinyalsa/test/agmmixer.h
+++ b/plugins/tinyalsa/test/agmmixer.h
@@ -86,13 +86,13 @@ void get_agm_usb_audio_config_payload(uint8_t** payload, size_t* size, uint32_t 
 int set_agm_group_device_config(struct mixer *mixer, char *intf_name, struct group_config *config);
 int set_agm_group_mux_config(struct mixer *mixer, unsigned int device, struct group_config *config, char *intf_name, unsigned int channels);
 int connect_play_pcm_to_cap_pcm(struct mixer *mixer, unsigned int p_device, unsigned int c_device);
-int set_agm_audio_intf_metadata(struct mixer *mixer, char *intf_name, unsigned int dkv, enum usecase_type, int rate, int bitwidth, uint32_t val);
-int set_agm_stream_metadata_type(struct mixer *mixer, int device, char *val, enum stream_type stype);
-int set_agm_streamdevice_metadata(struct mixer *mixer, int device, uint32_t val, enum usecase_type usecase, enum stream_type stype,
+int set_agm_audio_intf_metadata(struct mixer *mixer, char *intf_name, unsigned int device_kv, enum usecase_type, int rate, int bitwidth, uint32_t stream_kv);
+int set_agm_stream_metadata_type(struct mixer *mixer, int device, char *type, enum stream_type stype);
+int set_agm_streamdevice_metadata(struct mixer *mixer, int device, uint32_t stream_kv, enum usecase_type usecase, enum stream_type stype,
                                   char *intf_name, unsigned int devicepp_kv);
-int set_agm_stream_metadata(struct mixer *mixer, int device, uint32_t val, enum usecase_type utype, enum stream_type stype,
+int set_agm_stream_metadata(struct mixer *mixer, int device, uint32_t stream_kv, enum usecase_type utype, enum stream_type stype,
                             unsigned int instance_kv);
-int set_agm_capture_stream_metadata(struct mixer *mixer, int device, uint32_t val, enum usecase_type utype, enum stream_type stype,
+int set_agm_capture_stream_metadata(struct mixer *mixer, int device, uint32_t stream_kv, enum usecase_type utype, enum stream_type stype,
                             unsigned int instance_kv);
 int connect_agm_audio_intf_to_stream(struct mixer *mixer, unsigned int device,
                                   char *intf_name, enum stream_type, bool connect);
@@ -107,9 +107,9 @@ int agm_mixer_get_event_param(struct mixer *mixer, int device, enum stream_type 
 int agm_mixer_get_buf_tstamp(struct mixer *mixer, int device, enum stream_type stype, uint64_t *tstamp);
 int get_device_media_config(char* filename, char *intf_name, struct device_config *config);
 int get_group_device_info(char* filename, char *intf_name, struct group_config *config);
-int configure_mfc(struct mixer *mixer, int device, char *intf_name, int tag, enum stream_type stype, unsigned int rate,
-                       unsigned int channels, unsigned int bits, uint32_t miid);
+int configure_mfc(struct mixer *mixer, int device, enum stream_type stype, unsigned int rate, unsigned int channels, 
+                  unsigned int bits, uint32_t miid);
 int set_agm_dp_audio_config_metadata(char *intf_name, struct mixer *mixer, uint32_t miid, unsigned int channels);
-int configure_pcm_converter(struct mixer *mixer, int device, char *intf_name, int tag,
-        enum stream_type stype, unsigned int rate, unsigned int channels, unsigned int bits);
+int configure_pcm_converter(struct mixer *mixer, int device, enum stream_type stype, unsigned int channels, 
+                            unsigned int bits, uint32_t miid);
 #endif

--- a/plugins/tinyalsa/test/agmplay.c
+++ b/plugins/tinyalsa/test/agmplay.c
@@ -84,7 +84,7 @@ void stream_close(int sig)
     close = 1;
 }
 
-static void usage(void)
+static void usage(char *progname)
 {
     printf(" Usage: %s file.wav [-help print usage] [-D card] [-d device]\n"
            " [-c channels] [-r rate] [-b bits]\n"
@@ -97,7 +97,7 @@ static void usage(void)
            " [is_24_LE] : [0-1] Only to be used if user wants to play S24_LE clip\n"
            " [-usb_d usb device]\n"
            " 0: If clip bps is 32, and format is S32_LE\n"
-           " 1: If clip bps is 24, and format is S24_LE\n");
+           " 1: If clip bps is 24, and format is S24_LE\n", progname);
 }
 
 int main(int argc, char **argv)
@@ -130,7 +130,7 @@ int main(int argc, char **argv)
     }
 
     if (argc < 3) {
-        usage();
+        usage(argv[0]);
         return 1;
     }
 
@@ -261,7 +261,7 @@ int main(int argc, char **argv)
             if (*argv)
                 usb_device = atoi(*argv);
         } else if (strcmp(*argv, "-help") == 0) {
-            usage();
+            usage(argv[0]);
         }
         if (*argv)
             argv++;
@@ -440,9 +440,8 @@ void play_sample(FILE *file, unsigned int card, unsigned int device, unsigned in
         if (ret) {
             printf("PCM Converter not present for this graph\n");
         } else {
-            if (configure_pcm_converter(mixer, device, intf_name[index], STREAM_PCM_CONVERTER,
-                                STREAM_PCM, fmt.sample_rate, fmt.num_channels,
-                                fmt.bits_per_sample)) {
+            if (configure_pcm_converter(mixer, device, STREAM_PCM, 
+                                        fmt.num_channels, fmt.bits_per_sample, miid)) {
                 printf("Failed to configure pcm converter\n");
                 goto err_close_mixer;
             }
@@ -452,9 +451,8 @@ void play_sample(FILE *file, unsigned int card, unsigned int device, unsigned in
         if (ret) {
             printf("MFC not present for this graph\n");
         } else {
-            if (configure_mfc(mixer, device, intf_name[index], PER_STREAM_PER_DEVICE_MFC,
-                           STREAM_PCM, dev_config[index].rate, dev_config[index].ch,
-                           dev_config[index].bits, miid)) {
+            if (configure_mfc(mixer, device, STREAM_PCM, dev_config[index].rate, 
+                dev_config[index].ch, dev_config[index].bits, miid)) {
                 printf("Failed to configure pspd mfc\n");
                 goto err_close_mixer;
             }


### PR DESCRIPTION
- Remove unused parameters from configure_mfc() and configure_pcm_converter() (tag, intf_name, rate)
- Remove unused local variables in set_agm_group_device_config()
- Fix memory leaks in set_agm_dp_audio_config_metadata()
- Fix usage() to display actual program name
- Rename ambiguous parameters (val -> stream_kv, dkv -> device_kv, val -> type, val_len -> tag_config_len/p_stream_len)
- Simplify get_tinyalsa_pcm_bit_width() control flow
- Add const qualifier to get_pcm_format() parameter
- Update all callers to match new signatures