### PR TITLE
agm: Add SwBinder IPC support and OpenWRT build system integration

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,17 @@
 if AGM_NO_IPC
 SUBDIRS = snd_parser service plugins/tinyalsa plugins/tinyalsa/test plugins/alsalib
-else
+all-local:
+	@echo "Building with AGM_NO_IPC"
+endif
+
+if AGM_IPC_SWBINDER
+SUBDIRS = snd_parser service ipc/SwBinders/agm_server ipc/SwBinders/agm_client plugins/tinyalsa
+all-local:
+	@echo "Building for AGM_IPC_SWBINDER"
+endif
+
+if AGM_IPC_DBUS
 SUBDIRS = snd_parser service ipc/DBus/agm_client ipc/DBus/agm_server plugins/tinyalsa plugins/tinyalsa/test plugins/alsalib
+all-local:
+	@echo "Building with AGM_IPC_DBUS"
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -72,22 +72,39 @@ AC_ARG_WITH([no_ipc],
     [with_no_ipc=no])
 AM_CONDITIONAL([AGM_NO_IPC], [test "x${with_no_ipc}" = "xyes"])
 
+AC_ARG_WITH([ipc_dbus],
+    AS_HELP_STRING([--with-dbus],[enables dbus ipc communication to AGM (default is no)]),
+    [with_ipc_dbus=$withval],
+    [with_ipc_dbus=no])
+AM_CONDITIONAL([AGM_IPC_DBUS], [test "x${with_ipc_dbus}" = "xyes"])
 
+AC_ARG_WITH([ipc_swbinder],
+    AS_HELP_STRING([--with-sw-binder], [enable SwBinder based ipc communication to AGM (default is no)]),
+    [with_ipc_swbinder=$withval],
+    [with_ipc_swbinder=no])
+AM_CONDITIONAL([AGM_IPC_SWBINDER], [test "x${with_ipc_swbinder}" = "xyes"])
+
+AC_ARG_WITH([openwrt],
+    AS_HELP_STRING([use openwrt (default is no)]),
+    [with_openwrt=$withval],
+    [with_openwrt=no])
+AM_CONDITIONAL([BUILDSYSTEM_OPENWRT], [test "x${with_openwrt}" = "xyes"])
 PKG_CHECK_MODULES([SPF], [spf])
 AC_SUBST(SPF_CFLAGS)
 
-
+if (test "x${with_openwrt}" = "xno"); then
 PKG_CHECK_MODULES([KVH2XML], [kvh2xml])
 AC_SUBST([KVH2XML_CFLAGS])
+fi
 
 # Check dependency only if with_no_ipc is not set
-if (test "x${with_no_ipc}" = "xno"); then
+if (test "x${with_ipc_dbus}" = "xyes"); then
 PKG_CHECK_MODULES(DBUS, [ dbus-1 >= 1.4.12 ], dummy=yes,
                  AC_MSG_ERROR(dbus-1 >= 1.4.12 is required))
-fi
 
 AC_SUBST(DBUS_CFLAGS)
 AC_SUBST(DBUS_LIBS)
+fi
 
 AC_CHECK_FUNCS([strlcpy])
 AM_CONDITIONAL(USE_G_STR_FUNC, ! test "x$ac_cv_func_strlcpy" = "xyes")
@@ -108,6 +125,10 @@ plugins/tinyalsa/test/Makefile
 plugins/tinyalsa/test/agmtest.pc
 plugins/alsalib/Makefile
 plugins/alsalib/agmalsaplugin.pc
+ipc/SwBinders/agm_server/Makefile
+ipc/SwBinders/agm_server/agmserver.pc
+ipc/SwBinders/agm_client/Makefile
+ipc/SwBinders/agm_client/agmclient.pc
 )
 
 AC_OUTPUT

--- a/ipc/SwBinders/agm_client/Makefile.am
+++ b/ipc/SwBinders/agm_client/Makefile.am
@@ -1,9 +1,12 @@
 
-AM_CPPFLAGS := -I $(top_srcdir) -I $(PKG_CONFIG_SYSROOT_DIR)/usr/include/agm/
+AM_CPPFLAGS = -I $(srcdir) \
+	      -I $(PKG_CONFIG_SYSROOT_DIR)/usr/include/agm/ \
+	      -I $(top_srcdir)/ipc/SwBinders/agm_server/inc/ \
+	      -I $(top_srcdir)/service/inc/public/
 AM_CPPFLAGS += -DDYNAMIC_LOG_ENABLED
 lib_LTLIBRARIES      = libagmclientwrapper.la
 libagmclientwrapper_ladir = $(libdir)
-libagmclientwrapper_la_SOURCES   = src/agm_client_wrapper.cpp
-libagmclientwrapper_la_CPPFLAGS := $(AM_CPPFLAGS)
-libagmclientwrapper_la_LDFLAGS   = -lcutils -llog -ldl -lbinder -shared -avoid-version -lutils -lrt
-libagmclientwrapper_la_LIBADD     =  -lagmproxy -laudio_log_utils
+libagmclientwrapper_la_SOURCES  = src/agm_client_wrapper.cpp
+libagmclientwrapper_la_CPPFLAGS = $(AM_CPPFLAGS)
+libagmclientwrapper_la_LDFLAGS  = -lcutils -llog -ldl -lbinder -shared -avoid-version -lutils -lrt
+libagmclientwrapper_la_LIBADD   = -L$(top_builddir)/ipc/SwBinders/agm_server/.libs -lagmproxy -laudio_log_utils

--- a/ipc/SwBinders/agm_server/Makefile.am
+++ b/ipc/SwBinders/agm_server/Makefile.am
@@ -2,14 +2,14 @@ pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = agmserver.pc
 EXTRA_DIST = $(pkgconfig_DATA)
 
-h_sources  = $(top_srcdir)/inc/ipc_interface.h
-h_sources += $(top_srcdir)/inc/agm_death_notifier.h
-h_sources += $(top_srcdir)/inc/agm_callback.h
+h_sources  = $(srcdir)/inc/ipc_interface.h
+h_sources += $(srcdir)/inc/agm_death_notifier.h
+h_sources += $(srcdir)/inc/agm_callback.h
 
-AM_CPPFLAGS := -I $(top_srcdir) -I $(PKG_CONFIG_SYSROOT_DIR)/usr/include/agm/\
-               -I $(PKG_CONFIG_SYSROOT_DIR)/usr/include/qti-agm-service\
-               -I ${top_srcdir}/inc \
-               -I ${top_srcdir}
+AM_CPPFLAGS = -I $(srcdir) -I ${srcdir}/inc \
+              -I $(top_srcdir)/service/inc/public/ \
+              -I $(PKG_CONFIG_SYSROOT_DIR)/usr/include/agm/ \
+              -I $(PKG_CONFIG_SYSROOT_DIR)/usr/include/qti-agm-service
 
 AM_CPPFLAGS += -D__unused=__attribute__\(\(__unused__\)\)
 AM_CPPFLAGS += -DDYNAMIC_LOG_ENABLED
@@ -17,21 +17,21 @@ library_include_HEADERS = $(h_sources)
 library_includedir = $(includedir)/qti-agm-service/
 
 lib_LTLIBRARIES = libagmserverwrapper.la
-libagmserverwrapper_la_SOURCES   = ${top_srcdir}/src/agm_death_notifier.cpp ${top_srcdir}/src/agm_server_wrapper.cpp ${top_srcdir}/src/agm_callback.cpp
+libagmserverwrapper_la_SOURCES   = ${srcdir}/src/agm_death_notifier.cpp ${srcdir}/src/agm_server_wrapper.cpp ${srcdir}/src/agm_callback.cpp
 
-libagmserverwrapper_la_CPPFLAGS := $(AM_CPPFLAGS)
-libagmserverwrapper_la_LIBADD = -lagm -laudio_log_utils
+libagmserverwrapper_la_CPPFLAGS = $(AM_CPPFLAGS)
 libagmserverwrapper_la_LDFLAGS   = -lcutils -llog -ldl -lbinder -shared -avoid-version -lutils -lpthread
 
 lib_LTLIBRARIES += libagmproxy.la
-libagmproxy_la_SOURCES   = ${top_srcdir}/src/ipc_proxy_server.cpp
-libagmproxy_la_CPPFLAGS := $(AM_CPPFLAGS)
+libagmproxy_la_SOURCES   = ${srcdir}/src/ipc_proxy_server.cpp
+libagmproxy_la_CPPFLAGS = $(AM_CPPFLAGS)
 libagmproxy_la_LIBADD = libagmserverwrapper.la
 libagmproxy_la_LDFLAGS   = -lcutils -llog -ldl -lbinder -shared -avoid-version -lutils -lpthread
 
-bin_PROGRAMS := agm_server
-agm_server_SOURCES  := ${top_srcdir}/src/agm_server_daemon.cpp
+bin_PROGRAMS = agm_server
+agm_server_SOURCES  = ${srcdir}/src/agm_server_daemon.cpp
 
-agm_server_la_CPPFLAGS := $(AM_CPPFLAGS)
-agm_server_LDADD    := libagmproxy.la -laudio_log_utils
-agm_server_la_LDFLAGS   = -lcutils -llog -ldl -lbinder -shared -avoid-version -lutils
+agm_server_CPPFLAGS = $(AM_CPPFLAGS)
+agm_server_LDADD    = libagmproxy.la -laudio_log_utils
+libagmserverwrapper_la_LIBADD = -L$(top_builddir)/service/.libs -lagm -laudio_log_utils
+agm_server_LDFLAGS   = -lcutils -llog -ldl -lbinder -shared -avoid-version -lutils

--- a/plugins/tinyalsa/Makefile.am
+++ b/plugins/tinyalsa/Makefile.am
@@ -11,7 +11,9 @@ if USE_G_STR_FUNC
 AM_CFLAGS += -Dstrlcpy=g_strlcpy -Dstrlcat=g_strlcat
 endif
 AM_CFLAGS += -DAGM_USE_SYSLOG
+if !BUILDSYSTEM_OPENWRT
 AM_CFLAGS += @KVH2XML_CFLAGS@
+endif
 AM_CFLAGS += -D__unused=__attribute__\(\(__unused__\)\)
 AM_CFLAGS += -Wl,-z,defs
 
@@ -25,9 +27,15 @@ if AGM_NO_IPC
 libagm_pcm_plugin_la_CFLAGS += -DAGM_NO_IPC
 libagm_pcm_plugin_la_LDFLAGS += -L$(top_builddir)/service/.libs
 libagm_pcm_plugin_la_LIBADD += -lagm
-else
+endif
+
+if AGM_IPC_DBUS
 libagm_pcm_plugin_la_LDFLAGS += -L$(top_builddir)/ipc/DBus/agm_client/.libs
 libagm_pcm_plugin_la_LIBADD += -lagmclient
+endif
+
+if AGM_IPC_SWBINDER
+libagm_pcm_plugin_la_LIBADD  += -L$(top_builddir)/ipc/SwBinders/agm_client/.libs -lagmclientwrapper
 endif
 
 #lib_LTLIBRARIES      += libtinycompress_module_agm.la
@@ -54,7 +62,13 @@ if AGM_NO_IPC
 libagm_mixer_plugin_la_CFLAGS += -DAGM_NO_IPC
 libagm_mixer_plugin_la_LDFLAGS += -L$(top_builddir)/service/.libs
 libagm_mixer_plugin_la_LIBADD += -lagm
-else
+endif
+
+if AGM_IPC_DBUS
 libagm_mixer_plugin_la_LIBADD += -lagmclient
 libagm_mixer_plugin_la_LDFLAGS += -L$(top_builddir)/ipc/DBus/agm_client/.libs
+endif
+
+if AGM_IPC_SWBINDER
+libagm_mixer_plugin_la_LIBADD += -L$(top_builddir)/ipc/SwBinders/agm_client/.libs/ -lagmclientwrapper
 endif

--- a/service/Makefile.am
+++ b/service/Makefile.am
@@ -6,11 +6,11 @@ h_sources = ./inc/public/agm/agm_api.h \
             ./inc/public/agm/agm_list.h \
             ./inc/public/agm/utils.h
 
-AM_CFLAGS = @SPF_CFLAGS@
-AM_CFLAGS += -I $(srcdir)/inc/public
-AM_CFLAGS += -I $(srcdir)/inc/private -I $(top_srcdir)/snd_parser/inc
-AM_CFLAGS += @KVH2XML_CFLAGS@
-AM_CFLAGS += -Wl,-z,defs
+AM_CFLAGS = -I $(srcdir)/inc/public \
+            -I $(srcdir)/inc/private \
+            -I $(top_srcdir)/snd_parser/inc \
+            -I $(top_builddir)/src/system/core/include/log/
+
 library_include_HEADERS = $(h_sources)
 library_includedir = $(includedir)/agm
 
@@ -22,6 +22,14 @@ agm_sources = ./src/graph.c \
               ./src/session_obj.c \
               ./src/utils.c \
               ./src/agm.c
+if BUILDSYSTEM_OPENWRT
+agm_sources += ./src/agm_memlogger.c
+AM_CFLAGS += -DDYNAMIC_LOG_ENABLED
+else
+AM_CFLAGS += -Wl,-z,defs \
+             @SPF_CFLAGS@ \
+             @KVH2XML_CFLAGS@
+endif
 
 lib_LTLIBRARIES = libagm.la
 libagm_la_SOURCES = $(agm_sources)
@@ -38,7 +46,11 @@ endif
 if USE_SYSLOG
 libagm_la_CFLAGS += -DAGM_USE_SYSLOG
 endif
+if BUILDSYSTEM_OPENWRT
+libagm_la_LIBADD += -laudio_log_utils -larmemlog
+else
 libagm_la_CFLAGS += -DAGM_MEMLOG_UNSUPPORTED
+endif
 
 if USE_GLIB
 libagm_la_LIBADD += -lglib-2.0


### PR DESCRIPTION
Add configure options for SwBinder IPC (--with-sw-binder) & OpenWRT (--with-openwrt). Refactor build system to support three IPC modes: no-IPC, DBus, and SwBinder.
Update SwBinder client/server Makefiles with proper include paths, library dependencies & OpenWRT-specific build flags. Update tinyalsa plugins for SwBinder IPC linking & memory logger support for OpenWRT builds.