### PR TITLE
plugins: tinyalsa: Register new mixer control for CSHM

### DIFF
--- a/ipc/DBus/agm_client/src/agm_client_wrapper_dbus.cpp
+++ b/ipc/DBus/agm_client/src/agm_client_wrapper_dbus.cpp
@@ -2170,6 +2170,19 @@ int agm_get_group_aif_info_list(struct aif_info *aif_list, size_t *num_groups){
     return 0;
 }
 
+int agm_cshm_alloc(uint32_t size, agm_cshm_info *info) {
+    return 0;
+}
+
+int agm_cshm_msg(uint32_t mem_id, uint32_t offset, uint32_t length,
+                    uint32_t miid, uint32_t prop_flag) {
+    return 0;
+}
+
+int agm_cshm_dealloc(uint32_t mem_id)  {
+    return 0;
+}
+
 int agm_init() {
     GError *error = NULL;
     int rc = 0;

--- a/ipc/DBus/agm_server/src/agm_server_wrapper_dbus.cpp
+++ b/ipc/DBus/agm_server/src/agm_server_wrapper_dbus.cpp
@@ -2509,6 +2509,19 @@ static void ipc_agm_session_open(DBusConnection *conn,
     AGM_LOGD("%s :Exit ", __func__);
     return;
 }
+static void ipc_agm_cshm_alloc(
+                int32_t size, const agm_cshm_info &in_info, agm_cshm_info *_aidl_return) {
+    return;
+}
+static void ipc_agm_cshm_msg(int32_t in_mem_id, int32_t in_offset,
+            int32_t in_length, int32_t in_miid, int32_t in_prop_flag) {
+    return;
+}
+
+static void ipc_agm_cshm_dealloc(int32_t mem_id) {
+    return;
+}
+
 
 /* Initialize module data. Get dbus connection and register module interface
     with the connection */

--- a/ipc/SwBinders/agm_client/src/agm_client_wrapper.cpp
+++ b/ipc/SwBinders/agm_client/src/agm_client_wrapper.cpp
@@ -516,3 +516,16 @@ int agm_session_get_buf_info(uint32_t session_id, struct agm_buf_info *buf_info,
     ALOGE("%s: agm service is not running\n", __func__);
     return -EAGAIN;
 }
+
+int agm_cshm_alloc(uint32_t size, agm_cshm_info *info) {
+    return -EAGAIN;
+}
+
+int agm_cshm_msg(uint32_t mem_id, uint32_t offset, uint32_t length,
+                    uint32_t miid, uint32_t prop_flag) {
+    return -EAGAIN;
+}
+
+int agm_cshm_dealloc(uint32_t mem_id)  {
+    return -EAGAIN;
+}

--- a/ipc/SwBinders/agm_server/inc/ipc_interface.h
+++ b/ipc/SwBinders/agm_server/inc/ipc_interface.h
@@ -151,6 +151,11 @@ class IAgmService: public ::android::IInterface
                                     uint32_t silence) = 0;
         virtual int ipc_agm_session_get_buf_info(uint32_t session_id,
                            struct agm_buf_info *buf_info, uint32_t flag) = 0;
+        virtual int ipc_agm_cshm_alloc(int32_t size,
+            const AgmCshmInfo &in_info, AgmCshmInfo *_aidl_return) = 0;
+        virtual int ipc_agm_cshm_msg(int32_t in_mem_id, int32_t in_offset,
+            int32_t in_length, int32_t in_miid, int32_t in_prop_flag) = 0;
+        virtual int ipc_agm_cshm_dealloc(int32_t mem_id) = 0;
 };
 
 class BnAgmService : public ::android::BnInterface<IAgmService> {

--- a/ipc/SwBinders/agm_server/src/agm_server_wrapper.cpp
+++ b/ipc/SwBinders/agm_server/src/agm_server_wrapper.cpp
@@ -285,3 +285,23 @@ int AgmService::ipc_agm_session_get_buf_info(uint32_t session_id,
     ALOGV("%s called\n", __func__);
     return agm_session_get_buf_info(session_id, buf_info, flag);
 };
+
+int AgmService::ipc_agm_session_get_buf_info(uint32_t session_id,
+                       struct agm_buf_info *buf_info, uint32_t flag) {
+    ALOGV("%s called\n", __func__);
+    return agm_session_get_buf_info(session_id, buf_info, flag);
+};
+
+int AgmService::ipc_agm_cshm_alloc(
+                int32_t size, const agm_cshm_info &in_info, agm_cshm_info *_aidl_return) {
+    return 0;
+}
+int AgmService::ipc_agm_cshm_msg(int32_t in_mem_id, int32_t in_offset,
+            int32_t in_length, int32_t in_miid, int32_t in_prop_flag) {
+
+    return 0;
+}
+
+int AgmService::ipc_agm_cshm_dealloc(int32_t mem_id) {
+    return 0;
+}

--- a/ipc/aidl/Android.bp
+++ b/ipc/aidl/Android.bp
@@ -19,12 +19,12 @@ aidl_interface {
     imports: [
         "android.hardware.common-V2",
     ],
+    frozen: true,
     versions_with_info: [
         {
             version: "1",
             imports: ["android.hardware.common-V2"],
         },
     ],
-    frozen: true,
 
 }

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.agm/1/.hash
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.agm/1/.hash
@@ -1,1 +1,1 @@
-efa4ab1ccef17baa301d81deca852ddc0bbafbfb
+911502163cfdc3a8ebbefd1960e38f135ed339f2

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.agm/1/vendor/qti/hardware/agm/AgmCshmCacheType.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.agm/1/vendor/qti/hardware/agm/AgmCshmCacheType.aidl
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause-Clear
+ */
+///////////////////////////////////////////////////////////////////////////////
+// THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //
+///////////////////////////////////////////////////////////////////////////////
+
+// This file is a snapshot of an AIDL file. Do not edit it manually. There are
+// two cases:
+// 1). this is a frozen version file - do not edit this in any case.
+// 2). this is a 'current' file. If you make a backwards compatible change to
+//     the interface (from the latest frozen version), the build system will
+//     prompt you to update this file with `m <name>-update-api`.
+//
+// You must not make a backward incompatible change to any AIDL file built
+// with the aidl_interface module type with versions property set. The module
+// type is used to build AIDL files in a way that they can be used across
+// independently updatable components of the system. If a device is shipped
+// with such a backward incompatible change, it has a high risk of breaking
+// later when a module using the interface is updated, e.g., Mainline modules.
+
+package vendor.qti.hardware.agm;
+@Backing(type="int") @VintfStability
+enum AgmCshmCacheType {
+  CACHED = 1,
+  UNCACHED = 2,
+}

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.agm/1/vendor/qti/hardware/agm/AgmCshmInfo.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.agm/1/vendor/qti/hardware/agm/AgmCshmInfo.aidl
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause-Clear
+ */
+///////////////////////////////////////////////////////////////////////////////
+// THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //
+///////////////////////////////////////////////////////////////////////////////
+
+// This file is a snapshot of an AIDL file. Do not edit it manually. There are
+// two cases:
+// 1). this is a frozen version file - do not edit this in any case.
+// 2). this is a 'current' file. If you make a backwards compatible change to
+//     the interface (from the latest frozen version), the build system will
+//     prompt you to update this file with `m <name>-update-api`.
+//
+// You must not make a backward incompatible change to any AIDL file built
+// with the aidl_interface module type with versions property set. The module
+// type is used to build AIDL files in a way that they can be used across
+// independently updatable components of the system. If a device is shipped
+// with such a backward incompatible change, it has a high risk of breaking
+// later when a module using the interface is updated, e.g., Mainline modules.
+
+package vendor.qti.hardware.agm;
+@VintfStability
+parcelable AgmCshmInfo {
+  int memID;
+  vendor.qti.hardware.agm.AgmCshmCacheType type;
+  android.hardware.common.NativeHandle allocHandle;
+  int flags;
+}

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.agm/1/vendor/qti/hardware/agm/IAGM.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.agm/1/vendor/qti/hardware/agm/IAGM.aidl
@@ -1,6 +1,6 @@
 /**
-* Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause-Clear
 */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //
@@ -71,6 +71,9 @@ interface IAGM {
   void ipc_agm_set_params_with_tag(in int sessiondId, in int aifId, in vendor.qti.hardware.agm.AgmTagConfig tagConfig);
   void ipc_agm_set_params_with_tag_to_acdb(in int sessiondId, in int aifId, in byte[] payload);
   void ipc_agm_dump(in vendor.qti.hardware.agm.AgmDumpInfo dumpInfo);
+  vendor.qti.hardware.agm.AgmCshmInfo ipc_agm_cshm_alloc(in int size, in vendor.qti.hardware.agm.AgmCshmInfo info);
+  void ipc_agm_cshm_dealloc(in int memID);
+  void ipc_agm_cshm_msg(in int memID, in int offset, in int length, in int miid, in int propFlag);
   parcelable AgmReadWithMetadataReturn {
     vendor.qti.hardware.agm.AgmBuff buffer;
     int capturesSize;

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.agm/current/vendor/qti/hardware/agm/AgmCshmCacheType.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.agm/current/vendor/qti/hardware/agm/AgmCshmCacheType.aidl
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause-Clear
+ */
+///////////////////////////////////////////////////////////////////////////////
+// THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //
+///////////////////////////////////////////////////////////////////////////////
+
+// This file is a snapshot of an AIDL file. Do not edit it manually. There are
+// two cases:
+// 1). this is a frozen version file - do not edit this in any case.
+// 2). this is a 'current' file. If you make a backwards compatible change to
+//     the interface (from the latest frozen version), the build system will
+//     prompt you to update this file with `m <name>-update-api`.
+//
+// You must not make a backward incompatible change to any AIDL file built
+// with the aidl_interface module type with versions property set. The module
+// type is used to build AIDL files in a way that they can be used across
+// independently updatable components of the system. If a device is shipped
+// with such a backward incompatible change, it has a high risk of breaking
+// later when a module using the interface is updated, e.g., Mainline modules.
+
+package vendor.qti.hardware.agm;
+@Backing(type="int") @VintfStability
+enum AgmCshmCacheType {
+  CACHED = 1,
+  UNCACHED = 2,
+}

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.agm/current/vendor/qti/hardware/agm/AgmCshmInfo.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.agm/current/vendor/qti/hardware/agm/AgmCshmInfo.aidl
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause-Clear
+ */
+///////////////////////////////////////////////////////////////////////////////
+// THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //
+///////////////////////////////////////////////////////////////////////////////
+
+// This file is a snapshot of an AIDL file. Do not edit it manually. There are
+// two cases:
+// 1). this is a frozen version file - do not edit this in any case.
+// 2). this is a 'current' file. If you make a backwards compatible change to
+//     the interface (from the latest frozen version), the build system will
+//     prompt you to update this file with `m <name>-update-api`.
+//
+// You must not make a backward incompatible change to any AIDL file built
+// with the aidl_interface module type with versions property set. The module
+// type is used to build AIDL files in a way that they can be used across
+// independently updatable components of the system. If a device is shipped
+// with such a backward incompatible change, it has a high risk of breaking
+// later when a module using the interface is updated, e.g., Mainline modules.
+
+package vendor.qti.hardware.agm;
+@VintfStability
+parcelable AgmCshmInfo {
+  int memID;
+  vendor.qti.hardware.agm.AgmCshmCacheType type;
+  android.hardware.common.NativeHandle allocHandle;
+  int flags;
+}

--- a/ipc/aidl/aidl_api/vendor.qti.hardware.agm/current/vendor/qti/hardware/agm/IAGM.aidl
+++ b/ipc/aidl/aidl_api/vendor.qti.hardware.agm/current/vendor/qti/hardware/agm/IAGM.aidl
@@ -1,6 +1,6 @@
 /**
-* Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause-Clear
 */
 ///////////////////////////////////////////////////////////////////////////////
 // THIS FILE IS IMMUTABLE. DO NOT EDIT IN ANY CASE.                          //
@@ -71,6 +71,9 @@ interface IAGM {
   void ipc_agm_set_params_with_tag(in int sessiondId, in int aifId, in vendor.qti.hardware.agm.AgmTagConfig tagConfig);
   void ipc_agm_set_params_with_tag_to_acdb(in int sessiondId, in int aifId, in byte[] payload);
   void ipc_agm_dump(in vendor.qti.hardware.agm.AgmDumpInfo dumpInfo);
+  vendor.qti.hardware.agm.AgmCshmInfo ipc_agm_cshm_alloc(in int size, in vendor.qti.hardware.agm.AgmCshmInfo info);
+  void ipc_agm_cshm_dealloc(in int memID);
+  void ipc_agm_cshm_msg(in int memID, in int offset, in int length, in int miid, in int propFlag);
   parcelable AgmReadWithMetadataReturn {
     vendor.qti.hardware.agm.AgmBuff buffer;
     int capturesSize;

--- a/ipc/aidl/aidlconverter/inc/agm/AgmLegacyToAidl.h
+++ b/ipc/aidl/aidlconverter/inc/agm/AgmLegacyToAidl.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
+ * Changes from Qualcomm Technologies, Inc. are provided under the following license:
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  * SPDX-License-Identifier: BSD-3-Clause-Clear
  */
 
@@ -273,4 +274,6 @@ struct LegacyToAidl {
     */
     static void convertMmapBufferInfoToAidl(struct agm_buf_info *legacyBufferInfo,
                                             MmapBufInfo *aidlBufferInfo, int flags);
+
+    static aidl::android::hardware::common::NativeHandle convertfdToAidl(int fd);
 };

--- a/ipc/aidl/aidlconverter/src/AgmLegacyToAidl.cpp
+++ b/ipc/aidl/aidlconverter/src/AgmLegacyToAidl.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
+ * Changes from Qualcomm Technologies, Inc. are provided under the following license:
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  * SPDX-License-Identifier: BSD-3-Clause-Clear
  */
 
@@ -312,6 +313,12 @@ aidl::android::hardware::common::NativeHandle fdToNativeHandle(int fd, int intTo
     handle.fds.emplace_back(dup(fd));
     if (intToCopy != -1) handle.ints.emplace_back(intToCopy);
     return std::move(handle);
+}
+
+aidl::android::hardware::common::NativeHandle LegacyToAidl::convertfdToAidl(int fd) {
+    aidl::android::hardware::common::NativeHandle aidlfd;
+            aidlfd = fdToNativeHandle(fd, fd);
+            return std::move(aidlfd);
 }
 
 AgmBuff LegacyToAidl::convertAgmBufferToAidl(struct agm_buff *legacyBuffer, bool externalMemory,

--- a/ipc/aidl/client/AgmClientWrapper.cpp
+++ b/ipc/aidl/client/AgmClientWrapper.cpp
@@ -658,6 +658,39 @@ int agm_session_write_datapath_params(uint32_t session_id, struct agm_buff *buf)
             client->ipc_agm_session_write_datapath_params(session_id, aidlBuffer), __func__);
 }
 
+int32_t agm_cshm_alloc(uint32_t size, agm_cshm_info *info) {
+
+    const native_handle *FdHandle = nullptr;
+    auto client = getAgm();
+    RETURN_IF_AGM_SERVICE_NOT_REGISTERED(client);
+    AgmCshmInfo infoAidl;
+    AgmCshmInfo infoAidlResult;
+    infoAidl.type = static_cast<AgmCshmCacheType>(info->type);
+    infoAidl.flags = info->flags;
+    auto status = client->ipc_agm_cshm_alloc(size, infoAidl, &infoAidlResult);
+    auto fdInfo = AidlToLegacy::getFdIntFromNativeHandle(infoAidlResult.allocHandle);
+    info->mem_id = infoAidlResult.memID;
+    info->fd = fdInfo.first;
+
+    return statusTFromBinderStatus(status);
+}
+
+int agm_cshm_msg(uint32_t mem_id, uint32_t offset, uint32_t length,
+                    uint32_t miid, uint32_t prop_flag) {
+
+    auto client = getAgm();
+    RETURN_IF_AGM_SERVICE_NOT_REGISTERED(client);
+
+    return statusTFromBinderStatus(
+            client->ipc_agm_cshm_msg(mem_id, offset, length, miid, prop_flag));
+}
+
+int agm_cshm_dealloc(uint32_t mem_id)  {
+    auto client = getAgm();
+    RETURN_IF_AGM_SERVICE_NOT_REGISTERED(client);
+    return statusTFromBinderStatus(client->ipc_agm_cshm_dealloc(mem_id));
+}
+
 int agm_dump(struct agm_dump_info *dump_info) {
     return 0;
 }

--- a/ipc/aidl/server/AgmServerWrapper.cpp
+++ b/ipc/aidl/server/AgmServerWrapper.cpp
@@ -951,4 +951,27 @@ AgmServerWrapper::~AgmServerWrapper() {
 ::ndk::ScopedAStatus AgmServerWrapper::ipc_agm_dump(const AgmDumpInfo &in_dumpInfo) {
     return ScopedAStatus::ok();
 }
+
+::ndk::ScopedAStatus AgmServerWrapper::ipc_agm_cshm_alloc(
+                int32_t size, const AgmCshmInfo &in_info, AgmCshmInfo *_aidl_return) {
+
+    agm_cshm_info agm_info;
+    agm_info.type = (agm_cshm_type) in_info.type;
+    agm_info.flags = in_info.flags;
+    auto status = agm_cshm_alloc(size, &agm_info);
+    _aidl_return->allocHandle = LegacyToAidl::convertfdToAidl(agm_info.fd);
+    _aidl_return->memID = agm_info.mem_id;
+    return status_tToBinderResult(status);
+}
+::ndk::ScopedAStatus AgmServerWrapper::ipc_agm_cshm_msg(int32_t in_mem_id, int32_t in_offset,
+            int32_t in_length, int32_t in_miid, int32_t in_prop_flag) {
+
+    return status_tToBinderResult(
+            agm_cshm_msg(in_mem_id , in_offset, in_length, in_miid, in_prop_flag));
+}
+
+::ndk::ScopedAStatus AgmServerWrapper::ipc_agm_cshm_dealloc(int32_t mem_id) {
+    return status_tToBinderResult(agm_cshm_dealloc(mem_id));
+}
+
 }

--- a/ipc/aidl/server/AgmServerWrapper.h
+++ b/ipc/aidl/server/AgmServerWrapper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  * SPDX-License-Identifier: BSD-3-Clause-Clear
  */
 
@@ -8,7 +8,7 @@
 #include <agm/agm_api.h>
 #include <aidl/vendor/qti/hardware/agm/BnAGM.h>
 #include <aidl/vendor/qti/hardware/agm/IAGMCallback.h>
-
+#include <map>
 #include <log/log.h>
 #include <algorithm>
 #include <unordered_map>
@@ -271,7 +271,11 @@ class AgmServerWrapper : public BnAGM, public ISessionOps {
     ::ndk::ScopedAStatus ipc_agm_dump(
             const ::aidl::vendor::qti::hardware::agm::AgmDumpInfo &in_dumpInfo)
             override;
-
+    ::ndk::ScopedAStatus ipc_agm_cshm_alloc(int32_t size,
+            const AgmCshmInfo &in_info, AgmCshmInfo *_aidl_return) override;
+    ::ndk::ScopedAStatus ipc_agm_cshm_msg(int32_t in_mem_id, int32_t in_offset,
+            int32_t in_length, int32_t in_miid, int32_t in_prop_flag) override;
+    ::ndk::ScopedAStatus ipc_agm_cshm_dealloc(int32_t mem_id) override;
     void addSessionHandle(uint32_t sessionId, uint64_t handle) override;
     void removeSessionHandle(uint64_t handle) override;
     void connectSessionAif(uint32_t sessionId, uint32_t aifId, bool state) override;

--- a/ipc/aidl/vendor/qti/hardware/agm/AgmCshmCacheType.aidl
+++ b/ipc/aidl/vendor/qti/hardware/agm/AgmCshmCacheType.aidl
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause-Clear
+ */
+
+package vendor.qti.hardware.agm;
+/* AgmCshmCachetype type of memory to be allocated*/
+@Backing(type="int") @VintfStability
+enum AgmCshmCacheType {
+    /**
+    * Indicates that the allocated shared memory is cacheable.
+    * This typically offers better performance due to faster access,
+    * but may require explicit cache management
+    * to ensure data consistency between CPU and hardware devices.
+    */
+    CACHED = 1,
+    /**
+    * Indicates that the allocated shared memory is non-cacheable.
+    * This avoids issues with cache coherency,
+    * though it may result in slower access speeds.
+    */
+    UNCACHED = 2,
+}

--- a/ipc/aidl/vendor/qti/hardware/agm/AgmCshmInfo.aidl
+++ b/ipc/aidl/vendor/qti/hardware/agm/AgmCshmInfo.aidl
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause-Clear
+ */
+
+package vendor.qti.hardware.agm;
+
+import android.hardware.common.NativeHandle;
+
+import vendor.qti.hardware.agm.AgmCshmCacheType;
+
+/* memID memID of the memory allocated
+ * type type of the memory allocated
+ * fd fd of the memory allocated
+ * flags reserved flag for future usage*/
+@VintfStability
+parcelable AgmCshmInfo {
+    int memID;
+    AgmCshmCacheType type;
+    NativeHandle allocHandle;
+    int flags;
+}

--- a/ipc/aidl/vendor/qti/hardware/agm/IAGM.aidl
+++ b/ipc/aidl/vendor/qti/hardware/agm/IAGM.aidl
@@ -1,6 +1,6 @@
 /**
-* Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
-* SPDX-License-Identifier: BSD-3-Clause-Clear
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * SPDX-License-Identifier: BSD-3-Clause-Clear
 */
 
 package vendor.qti.hardware.agm;
@@ -20,6 +20,7 @@ import vendor.qti.hardware.agm.AifInfo;
 import vendor.qti.hardware.agm.Direction;
 import vendor.qti.hardware.agm.IAGMCallback;
 import vendor.qti.hardware.agm.MmapBufInfo;
+import vendor.qti.hardware.agm.AgmCshmInfo;
 
 @VintfStability
 interface IAGM {
@@ -541,4 +542,39 @@ interface IAGM {
     * check converstion details at: aidlconverter/inc/agm/BinderStatus.h
     */
     void ipc_agm_dump(in AgmDumpInfo dumpInfo);
+
+    /**
+    * Call to allocate shared memory
+    * @param size size of memory to be allocated
+    * @param AgmCshmInfo AgmCshmInfo is a structure.
+    * if return value is zero, AGM will copy memID and fd to AgmCshmInfo.
+    * @return AgmCshmInfo AgmCshmInfo is a structure.
+    * @throws ServiceSpecificException with one of the values defined in Status.aidl
+    * These exceptions are used to preserve the linux error codes over AIDL.
+    * check converstion details at: aidlconverter/inc/agm/BinderStatus.h
+    */
+    AgmCshmInfo ipc_agm_cshm_alloc(in int size, in AgmCshmInfo info);
+
+    /**
+    * Call to deallocate shared memory
+    * @param memID mem ID which is needed to be deallocated.
+    * @throws ServiceSpecificException with one of the values defined in Status.aidl
+    * These exceptions are used to preserve the linux error codes over AIDL.
+    * check converstion details at: aidlconverter/inc/agm/BinderStatus.h
+    */
+    void ipc_agm_cshm_dealloc(in int memID);
+
+    /**
+    * Send a Global MSG to a module
+    * @param memID memory ID of allocated memory
+    * @param offset offset of the memory
+    * @param length length of the chunk of memory
+    * @param miid ID of the module for which message is sent
+    * @param propFlag Flag conveying additional info regarding the MSG.
+    * @throws ServiceSpecificException with one of the values defined in Status.aidl
+    * These exceptions are used to preserve the linux error codes over AIDL.
+    * check converstion details at: aidlconverter/inc/agm/BinderStatus.h
+    */
+    void ipc_agm_cshm_msg(in int memID, in int offset, in int length, in int miid,
+                    in int propFlag);
 }

--- a/plugins/tinyalsa/Android.mk
+++ b/plugins/tinyalsa/Android.mk
@@ -141,3 +141,6 @@ LOCAL_HEADER_LIBRARIES += libaudiologutils_headers
 endif
 
 include $(BUILD_SHARED_LIBRARY)
+
+# Build agmpluginnative
+include $(LOCAL_PATH)/agmpluginnative.mk

--- a/plugins/tinyalsa/agmpluginnative.mk
+++ b/plugins/tinyalsa/agmpluginnative.mk
@@ -1,0 +1,143 @@
+LOCAL_PATH := $(call my-dir)
+# Build libagm_pcm_plugin_native
+include $(CLEAR_VARS)
+
+LOCAL_MODULE        := libagm_pcm_plugin_native
+LOCAL_MODULE_OWNER  := qti
+LOCAL_MODULE_TAGS   := optional
+LOCAL_VENDOR_MODULE := true
+
+# add for gcov dump
+ifeq ($(AUDIO_FEATURE_ENABLED_GCOV), true)
+LOCAL_CFLAGS += -g --coverage -fprofile-arcs -ftest-coverage
+LOCAL_CPPFLAGS += -g --coverage -fprofile-arcs -ftest-coverage
+LOCAL_LDFLAGS += -g --coverage -fprofile-arcs -ftest-coverage
+endif
+
+LOCAL_CFLAGS        += -Wall
+LOCAL_SRC_FILES     := src/agm_pcm_plugin.c
+
+LOCAL_HEADER_LIBRARIES := \
+    libagm_headers \
+    libarosal_headers
+
+LOCAL_SHARED_LIBRARIES := \
+    libsndcardparser \
+    libagm \
+    libutils \
+    libcutils \
+    liblog
+
+#if android version is R, refer to qtitinyxx otherwise use upstream ones
+#This assumes we would be using AR code only for Android R and subsequent versions.
+ifneq ($(filter 11 R, $(PLATFORM_VERSION)),)
+LOCAL_SHARED_LIBRARIES += libqti-tinyalsa
+else
+LOCAL_SHARED_LIBRARIES += liboss_tinyalsa
+endif
+
+ifeq ($(strip $(AUDIO_FEATURE_ENABLED_DYNAMIC_LOG)), true)
+LOCAL_CFLAGS           += -DDYNAMIC_LOG_ENABLED
+LOCAL_C_INCLUDES       += $(TOP)/external/expat/lib/expat.h
+LOCAL_SHARED_LIBRARIES += libaudio_log_utils
+LOCAL_SHARED_LIBRARIES += libexpat
+LOCAL_HEADER_LIBRARIES += libaudiologutils_headers
+endif
+
+include $(BUILD_SHARED_LIBRARY)
+
+# Build libagm_mixer_plugin_native
+include $(CLEAR_VARS)
+
+LOCAL_MODULE        := libagm_mixer_plugin_native
+LOCAL_MODULE_OWNER  := qti
+LOCAL_MODULE_TAGS   := optional
+LOCAL_VENDOR_MODULE := true
+LOCAL_SRC_FILES     := src/agm_mixer_plugin.c
+
+# add for gcov dump
+ifeq ($(AUDIO_FEATURE_ENABLED_GCOV), true)
+LOCAL_CFLAGS += -g --coverage -fprofile-arcs -ftest-coverage
+LOCAL_CPPFLAGS += -g --coverage -fprofile-arcs -ftest-coverage
+LOCAL_LDFLAGS += -g --coverage -fprofile-arcs -ftest-coverage
+endif
+
+LOCAL_HEADER_LIBRARIES := \
+    libagm_headers \
+    libarosal_headers
+
+LOCAL_SHARED_LIBRARIES := \
+    libsndcardparser \
+    libagm \
+    libcutils \
+    libutils \
+    liblog
+
+#if android version is R, refer to qtitinyxx otherwise use upstream ones
+#This assumes we would be using AR code only for Android R and subsequent versions.
+ifneq ($(filter 11 R, $(PLATFORM_VERSION)),)
+LOCAL_SHARED_LIBRARIES += libqti-tinyalsa
+else
+LOCAL_SHARED_LIBRARIES += liboss_tinyalsa
+endif
+
+ifeq ($(strip $(AUDIO_FEATURE_ENABLED_DYNAMIC_LOG)), true)
+LOCAL_CFLAGS           += -DDYNAMIC_LOG_ENABLED
+LOCAL_C_INCLUDES       += $(TOP)/external/expat/lib/expat.h
+LOCAL_SHARED_LIBRARIES += libaudio_log_utils
+LOCAL_SHARED_LIBRARIES += libexpat
+LOCAL_HEADER_LIBRARIES += libaudiologutils_headers
+endif
+
+include $(BUILD_SHARED_LIBRARY)
+
+# Build libtinycompress_module_agm_native
+include $(CLEAR_VARS)
+
+LOCAL_MODULE        := libtinycompress_module_agm_native
+LOCAL_MODULE_OWNER  := qti
+LOCAL_MODULE_TAGS   := optional
+LOCAL_VENDOR_MODULE := true
+
+LOCAL_C_INCLUDES    += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr/include
+LOCAL_ADDITIONAL_DEPENDENCIES += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr
+
+LOCAL_SRC_FILES     := src/agm_compress_plugin.c
+
+# add for gcov dump
+ifeq ($(AUDIO_FEATURE_ENABLED_GCOV), true)
+LOCAL_CFLAGS += -g --coverage -fprofile-arcs -ftest-coverage
+LOCAL_CPPFLAGS += -g --coverage -fprofile-arcs -ftest-coverage
+LOCAL_LDFLAGS += -g --coverage -fprofile-arcs -ftest-coverage
+endif
+
+LOCAL_HEADER_LIBRARIES := \
+    libagm_headers \
+    libarosal_headers
+
+LOCAL_SHARED_LIBRARIES := \
+    libsndcardparser \
+    libagm \
+    libutils \
+    libcutils \
+    liblog
+
+# Use flag based selection to use QTI vs open source tinycompress project
+
+ifeq ($(TARGET_USES_QTI_TINYCOMPRESS),true)
+LOCAL_SHARED_LIBRARIES += libqti-tinyalsa\
+                          libqti-tinycompress
+else
+LOCAL_SHARED_LIBRARIES += liboss_tinyalsa\
+                          liboss_tinycompress
+endif
+
+ifeq ($(strip $(AUDIO_FEATURE_ENABLED_DYNAMIC_LOG)), true)
+LOCAL_CFLAGS           += -DDYNAMIC_LOG_ENABLED
+LOCAL_C_INCLUDES       += $(TOP)/external/expat/lib/expat.h
+LOCAL_SHARED_LIBRARIES += libaudio_log_utils
+LOCAL_SHARED_LIBRARIES += libexpat
+LOCAL_HEADER_LIBRARIES += libaudiologutils_headers
+endif
+
+include $(BUILD_SHARED_LIBRARY)

--- a/service/inc/public/agm/agm_api.h
+++ b/service/inc/public/agm/agm_api.h
@@ -26,9 +26,8 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Changes from Qualcomm Innovation Center are provided under the following license:
- *
- * Copyright (c) 2022-2023, Qualcomm Innovation Center, Inc. All rights reserved.
+ * Changes from Qualcomm Technologies, Inc. are provided under the following license:
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  * SPDX-License-Identifier: BSD-3-Clause-Clear
  *
  */
@@ -156,6 +155,27 @@ enum agm_session_mode
     AGM_SESSION_NO_CONFIG,       /**< No Config mode*/
     AGM_SESSION_COMPRESS,        /**< Compress mode*/
 };
+
+/* Memory type */
+typedef enum {
+  CACHED = 1, /**< Indicates that the allocated shared memory is cacheable*/
+  UNCACHED /**< Indicates that the allocated shared memory is non-cacheable*/
+} agm_cshm_type;
+
+typedef struct {
+  uint32_t mem_id; /**< memID of the memory allocated*/
+  agm_cshm_type type; /**< type of the memory allocated*/
+  int64_t fd; /**< fd of the memory allocated*/
+  uint32_t flags; /**reserved flag for future usage*/
+} agm_cshm_info;
+
+typedef struct {
+  uint32_t mem_id; /**< memID of the memory allocated*/
+  uint32_t offset; /**< offset of memory allocated*/
+  uint32_t length; /**< Size of the chunk of memory*/
+  uint32_t miid; /**< module ID to which msg is sent*/
+  uint32_t flags; /**< Flags to provide additional information, if it is a release memory or not*/
+} agm_msg_config;
 
 struct agm_extern_alloc_buff_info{
     int      alloc_handle;/**< unique handle identifying extern mem allocation */
@@ -1217,6 +1237,38 @@ int agm_session_write_datapath_params(uint32_t session_id, struct agm_buff *buff
   */
 int agm_dump(struct agm_dump_info *dump_info);
 
+/**
+  * \brief Allocate shared memory and map it with SPF.
+  *
+  * \param[in] size - Size of memory to alloc in bytes.
+  * \param[in/out] info - Info regarding the allocated shared memory
+  *
+  *  \return 0 on success, error code on failure.
+  */
+int agm_cshm_alloc(uint32_t size, agm_cshm_info *info);
+
+ /**
+  * \brief Send a Global MSG to a module.
+  *
+  * \param[in] mem_id - Valid mem_id returned as part of agm_cshm_alloc.
+  * \param[in] offset - Offset from the beginning of allocted memory.
+  * \param[in] length - Length of the memory for module to use.
+  * \param[in] miid   - Module Instance ID of the module for which this
+  *                     MSG is intented.
+  * \param[in] flags - Flag conveying additional info regarding the MSG.
+  *
+  *  \return 0 on success, error code on failure.
+  */
+int agm_cshm_msg(uint32_t mem_id, uint32_t offset, uint32_t length, uint32_t miid, uint32_t flags);
+
+ /**
+  * \brief Unmap the shared memory with SPF and Deallocate it.
+  *
+  * \param[in] mem_id - Valid mem_id returned as part of agm_cshm_alloc.
+  *
+  *  \return 0 on success, error code on failure.
+  */
+int agm_cshm_dealloc(uint32_t mem_id);
 #ifdef __cplusplus
 }  /* extern "C" */
 #endif

--- a/service/src/agm.c
+++ b/service/src/agm.c
@@ -55,6 +55,7 @@
 #include "posal.h"
 #include "spf_main.h"
 #endif
+#include "gsl_intf.h"
 
 #define RETRY_INTERVAL_US 500 * 1000
 static bool agm_initialized = 0;

--- a/snd_parser/Android.mk
+++ b/snd_parser/Android.mk
@@ -8,6 +8,7 @@ LOCAL_VENDOR_MODULE  := true
 
 LOCAL_CFLAGS         := -Wno-unused-parameter -Wall
 LOCAL_CFLAGS         += -DCARD_DEF_FILE=\"/vendor/etc/card-defs.xml\"
+LOCAL_CFLAGS         += -DCARD_DEF_FILE_NATIVE=\"/vendor/etc/card-defs-native.xml\"
 
 LOCAL_C_INCLUDES            := $(LOCAL_PATH)/inc
 LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)/inc

--- a/snd_parser/Makefile.am
+++ b/snd_parser/Makefile.am
@@ -12,6 +12,7 @@ lib_includedir = $(includedir)/sndparser/
 AM_CFLAGS = -I $(srcdir)/inc -I $(top_srcdir)/service/inc/public
 AM_CFLAGS += -Wno-unused-parameter
 AM_CFLAGS += -DCARD_DEF_FILE=\"/etc/card-defs.xml\"
+AM_CFLAGS += -DCARD_DEF_FILE_NATIVE=\"/etc/card-defs-native.xml\"
 AM_CFLAGS += -Wl,-z,defs
 
 lib_LTLIBRARIES      = libsndcardparser.la

--- a/snd_parser/src/snd-card-parser.c
+++ b/snd_parser/src/snd-card-parser.c
@@ -25,9 +25,9 @@
 ** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
 ** OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 ** IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*  Changes from Qualcomm Innovation Center are provided under the following license:
+*  Changes from Qualcomm Technologies, Inc. are provided under the following license:
 *
-*  Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved.
+*  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 *  SPDX-License-Identifier: BSD-3-Clause-Clear
 **/
 
@@ -45,6 +45,7 @@
 
 #define MAX_PATH 256
 #define BUF_SIZE 1024
+#define SND_CARD_VIRTUAL_ID 100
 
 
 struct snd_prop_val_pair {
@@ -515,7 +516,11 @@ void *snd_card_def_get_card(unsigned int card)
 
     card_def = NULL;
     /* read XML */
-    file = fopen(CARD_DEF_FILE, "r");
+    if (card == SND_CARD_VIRTUAL_ID) {
+        file = fopen(CARD_DEF_FILE, "r");
+    } else {
+        file = fopen(CARD_DEF_FILE_NATIVE, "r");
+    }
     if (!file) {
         pthread_rwlock_unlock(&snd_rwlock);
         if (snd_card_name != NULL )


### PR DESCRIPTION
Commits: 
agm: add non-ipc plugin libs & support dynamic card-id xml parsing
agm: ipc: Add support for client shared memory feature
agm: Extend AGM interface for CSHM
plugins: tinyalsa: Register new mixer control for CSHM
agm: implement aidl apis in dbus and SW binders
snd_parser: Makefile.am: Add missing CARD_DEF_FILE_NATIVE macro
Include gsl_intf.h to resolve missing API references in agm.c
