### PR TITLE
snd_parser: Makefile.am: Add missing CARD_DEF_FILE_NATIVE macro

### DIFF
--- a/snd_parser/Makefile.am
+++ b/snd_parser/Makefile.am
@@ -12,6 +12,7 @@ lib_includedir = $(includedir)/sndparser/
 AM_CFLAGS = -I $(srcdir)/inc -I $(top_srcdir)/service/inc/public
 AM_CFLAGS += -Wno-unused-parameter
 AM_CFLAGS += -DCARD_DEF_FILE=\"/etc/card-defs.xml\"
+AM_CFLAGS += -DCARD_DEF_FILE_NATIVE=\"/etc/card-defs-native.xml\"
 AM_CFLAGS += -Wl,-z,defs
 
 lib_LTLIBRARIES      = libsndcardparser.la


### PR DESCRIPTION
Add missing CARD_DEF_FILE_NATIVE macro definition to Makefile.am to resolve compilation failure. The macro exists in Android.mk but was absent from the autotools build configuration, causing an undeclared identifier error in snd-card-parser.c.

Define the macro to specify the path to the native card definitions XML file for non-virtual sound cards.