### PR TITLE
Switch pre-merge workflow to pull_request_target trigger

### DIFF
--- a/.github/workflows/pre_merge_build.yml
+++ b/.github/workflows/pre_merge_build.yml
@@ -4,7 +4,7 @@ run-name: ${{ github.event.pull_request.number && 'Pre Merge Build PR:' || 'Pre 
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
     branches:
       - master


### PR DESCRIPTION
Use pull_request_target instead of pull_request for pre-merge builds. Ensure LAVA token availability for workflow execution. Allow secure access to required secrets during PR validation.