### PR TITLE
Upstream

### DIFF
--- a/ipc/DBus/agm_server/src/agm_server_wrapper_dbus.cpp
+++ b/ipc/DBus/agm_server/src/agm_server_wrapper_dbus.cpp
@@ -28,38 +28,9 @@
 **/
 
 /*
-** Changes from Qualcomm Innovation Center are provided under the following license:
-** Copyright (c) 2022 Qualcomm Innovation Center, Inc. All rights reserved.
-**
-** Redistribution and use in source and binary forms, with or without
-** modification, are permitted (subject to the limitations in the
-** disclaimer below) provided that the following conditions are met:
-**
-**    * Redistributions of source code must retain the above copyright
-**      notice, this list of conditions and the following disclaimer.
-**
-**    * Redistributions in binary form must reproduce the above
-**      copyright notice, this list of conditions and the following
-**      disclaimer in the documentation and/or other materials provided
-**      with the distribution.
-**
-**    * Neither the name of Qualcomm Innovation Center, Inc. nor the names of its
-**      contributors may be used to endorse or promote products derived
-**      from this software without specific prior written permission.
-**
-** NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
-** GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
-** HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-** WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-** MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-** IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-** ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-** DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
-** GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-** INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
-** IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
-** OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
-** IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+** Changes from Qualcomm Technologies, Inc. are provided under the following license:
+** Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+** SPDX-License-Identifier: BSD-3-Clause-Clear
 **/
 
 #define LOG_TAG "agm_server_wrapper_dbus"
@@ -104,7 +75,7 @@ typedef struct {
        Used to de-register callbacks when client dies abruptly */
     GList *callbacks;
 
-    char buf[16392];
+    void *buf;
     uint32_t buf_size;
     int thread_state;
     pthread_mutex_t lock;
@@ -505,6 +476,12 @@ static agm_session_data * get_session_data(agm_module_dbus_data *mdata,
                         g_hash_table_lookup(mdata->sessions,
                                        GUINT_TO_POINTER(session_id))) == NULL) {
         ses_data = (agm_session_data *)malloc(sizeof(agm_session_data));
+        if (ses_data == NULL) {
+            AGM_LOGE("Failed to allocate session data");
+            return NULL;
+        }
+        ses_data->buf = NULL;
+        ses_data->buf_size = 0;
         ses_data->session_id = session_id;
         ss << ses_data->session_id;
         obj_length = sizeof(char)*(strlen(AGM_OBJECT_PATH)) +
@@ -2091,6 +2068,23 @@ static void ipc_agm_session_set_config(DBusConnection *conn,
                             "agm_session_set_config failed.");
         return;
     }
+    pthread_mutex_lock(&ses_data->lock);
+    if (ses_data->buf == NULL || ses_data->buf_size != buffer_config.size) {
+        if (ses_data->buf != NULL) {
+            free(ses_data->buf);
+            ses_data->buf = NULL;
+        }
+        ses_data->buf = (void*) calloc(1, buffer_config.size);
+        if (ses_data->buf == NULL) {
+            AGM_LOGE("Cannot allocate memory for buffer\n");
+            pthread_mutex_unlock(&ses_data->lock);
+            agm_dbus_send_error(mdata->conn, msg, DBUS_ERROR_FAILED,
+                                "Cannot allocate memory for buffer");
+            return;
+        }
+        ses_data->buf_size = buffer_config.size;
+    }
+    pthread_mutex_unlock(&ses_data->lock);
 
     reply = dbus_message_new_method_return(msg);
     dbus_connection_send(conn, reply, NULL);
@@ -2407,6 +2401,11 @@ static void ipc_agm_session_close(DBusConnection *conn,
         agm_dbus_send_error(mdata->conn, msg, DBUS_ERROR_FAILED,
                             "agm_session_close failed.");
         return;
+    }
+
+    if (ses_data->buf != NULL) {
+        free(ses_data->buf);
+        ses_data->buf = NULL;
     }
 
     for (node = ses_data->callbacks; node != NULL; node = node->next) {

--- a/plugins/alsalib/Makefile.am
+++ b/plugins/alsalib/Makefile.am
@@ -11,6 +11,10 @@ AM_CFLAGS += $(GLIB_CFLAGS)
 AM_CFLAGS += -D__unused=__attribute__\(\(__unused__\)\) -D__LINUX__
 AM_CFLAGS += -I $(top_srcdir)/../../snd_parser/inc
 
+if USE_SYSLOG
+AM_CFLAGS += -DAGM_USE_SYSLOG
+endif
+
 if USE_G_STR_FUNC
 AM_CFLAGS += -Dstrlcpy=g_strlcpy -Dstrlcat=g_strlcat
 endif
@@ -18,7 +22,8 @@ endif
 
 if BUILD_ALSALIB
 
-lib_LTLIBRARIES      = libasound_module_pcm_agm.la
+alsaplugindir = $(libdir)/alsa-lib
+alsaplugin_LTLIBRARIES      = libasound_module_pcm_agm.la
 libasound_module_pcm_agm_la_SOURCES   = src/agm_io_plugin.c
 libasound_module_pcm_agm_la_CFLAGS = $(AM_CFLAGS)
 libasound_module_pcm_agm_la_LDFLAGS = -avoid-version -shared \
@@ -33,7 +38,7 @@ libasound_module_pcm_agm_la_LDFLAGS += -L$(top_builddir)/ipc/DBus/agm_client/.li
 libasound_module_pcm_agm_la_LIBADD  = -lasound -lsndcardparser -lagmclient
 endif
 
-lib_LTLIBRARIES      += libasound_module_ctl_agm.la
+alsaplugin_LTLIBRARIES      += libasound_module_ctl_agm.la
 libasound_module_ctl_agm_la_SOURCES   = src/agm_ctl_plugin.c
 libasound_module_ctl_agm_la_CFLAGS = $(AM_CFLAGS)
 

--- a/plugins/alsalib/src/agm_ctl_plugin.c
+++ b/plugins/alsalib/src/agm_ctl_plugin.c
@@ -25,6 +25,10 @@
 ** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
 ** OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 ** IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+** Changes from Qualcomm Technologies, Inc. are provided under the following license:
+** Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+** SPDX-License-Identifier: BSD-3-Clause-Clear
 **/
 
 #define LOG_TAG "PLUGIN: AGMCTL"
@@ -1177,6 +1181,9 @@ static int agmctl_read_bytes(snd_ctl_ext_t *ext, snd_ctl_ext_key_t key,
         break;
     case AGM_FE_CTL_NAME_EVENT:
         rc = agmctl_pcm_event_get(&agmctl->controls[key], data, len);
+        break;
+    case AGM_BE_CTL_NAME_METADATA:
+    case AGM_FE_CTL_NAME_METADATA:
         break;
     default:
         rc = -EINVAL;

--- a/plugins/alsalib/src/agm_io_plugin.c
+++ b/plugins/alsalib/src/agm_io_plugin.c
@@ -25,7 +25,12 @@
 ** WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
 ** OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 ** IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+** Changes from Qualcomm Technologies, Inc. are provided under the following license:
+** Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+** SPDX-License-Identifier: BSD-3-Clause-Clear
 **/
+
 #define LOG_TAG "PLUGIN: AGMIO"
 #include <stdio.h>
 #include <sys/poll.h>
@@ -37,7 +42,7 @@
 #include <agm/agm_api.h>
 #include <agm/agm_list.h>
 #include <snd-card-def.h>
-#include "utils.h"
+#include <agm/utils.h>
 
 #define ARRAY_SIZE(a)   (sizeof(a)/sizeof(a[0]))
 

--- a/plugins/alsalib/src/agm_io_plugin.c
+++ b/plugins/alsalib/src/agm_io_plugin.c
@@ -504,7 +504,7 @@ SND_PCM_PLUGIN_DEFINE_FUNC(agm)
     }
     priv->pcm_node = pcm_node;
 
-    snd_card_def_get_int(pcm_node, "session_mode", &sess_mode);
+    snd_card_def_get_int(pcm_node, "session_mode", (int *)&sess_mode);
 
     session_id = priv->device;
     ret = agm_session_open(session_id, sess_mode, &handle);

--- a/plugins/tinyalsa/test/agmcompresscap.c
+++ b/plugins/tinyalsa/test/agmcompresscap.c
@@ -54,8 +54,8 @@
  * the Free Software Foundation, Inc.,
  * 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * Changes from Qualcomm Innovation Center are provided under the following license:
- * Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved.
+ * Changes from Qualcomm Technologies, Inc. are provided under the following license:
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  * SPDX-License-Identifier: BSD-3-Clause-Clear
  */
 #include <stdint.h>
@@ -367,12 +367,16 @@ static void capture_samples(char *name, unsigned int card, unsigned int device,
     }
 
     compress = compress_open(card, device, COMPRESS_OUT, &config);
-    if (!compress || !is_compress_ready(compress)) {
+    if (!compress) {
         fprintf(stderr, "Unable to open Compress device %d:%d\n",
             card, device);
+        goto mixer_exit;
+    }
+
+    if (!is_compress_ready(compress)) {
         fprintf(stderr, "ERR: %s\n", compress_get_error(compress));
         goto mixer_exit;
-    };
+    }
 
     if (verbose)
         fprintf(finfo, "%s: Opened compress device\n", __func__);

--- a/plugins/tinyalsa/test/agmcompressplay.c
+++ b/plugins/tinyalsa/test/agmcompressplay.c
@@ -51,8 +51,8 @@
  * the Free Software Foundation, Inc.,
  * 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * Changes from Qualcomm Innovation Center are provided under the following license:
- * Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved.
+ * Changes from Qualcomm Technologies, Inc. are provided under the following license:
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  * SPDX-License-Identifier: BSD-3-Clause-Clear
  */
 
@@ -547,12 +547,17 @@ void play_samples(char *name, unsigned int card, unsigned int device, unsigned i
 
 
     compress = compress_open(card, device, COMPRESS_IN, &config);
-    if (!compress || !is_compress_ready(compress)) {
+    if (!compress) {
         fprintf(stderr, "Unable to open Compress device %d:%d\n",
                 card, device);
+        goto MIXER_EXIT;
+    }
+
+    if (!is_compress_ready(compress)) {
         fprintf(stderr, "ERR: %s\n", compress_get_error(compress));
         goto MIXER_EXIT;
-    };
+    }
+
     if (verbose)
         printf("%s: Opened compress device\n", __func__);
 

--- a/service/src/agm.c
+++ b/service/src/agm.c
@@ -57,8 +57,17 @@
 #endif
 #include "gsl_intf.h"
 
+#ifdef AGM_USE_CUTILS
+#include <cutils/properties.h>
+#endif
+#include <stdatomic.h>
+#include <sched.h>
+
 #define RETRY_INTERVAL_US 500 * 1000
 static bool agm_initialized = 0;
+static bool ats_thread_started = false;
+//Stop init retries when AGM is deinitialized
+static atomic_bool ats_stop_requested = ATOMIC_VAR_INIT(false);
 static pthread_t ats_thread;
 static const int MAX_RETRIES = 120;
 
@@ -68,6 +77,8 @@ static void *ats_init_thread(void *obj __unused)
     int retry = 0;
 
     while(retry++ < MAX_RETRIES) {
+        if (atomic_load(&ats_stop_requested))
+            break;
         ret = ats_init();
         if (0 != ret) {
             AGM_LOGE("ats_init failed retry %d err %d", retry, ret);
@@ -119,15 +130,17 @@ int agm_init()
 #ifndef AGM_MEMLOG_UNSUPPORTED
     agm_memlog_init();
 #endif
-    pthread_attr_init (&tattr);
+    pthread_attr_init(&tattr);
+    pthread_attr_setinheritsched(&tattr, PTHREAD_EXPLICIT_SCHED);
+    pthread_attr_setschedpolicy(&tattr, SCHED_FIFO);
     pthread_attr_getschedparam (&tattr, &param);
-    param.sched_priority = SCHED_FIFO;
+    param.sched_priority = sched_get_priority_min(SCHED_FIFO);
     pthread_attr_setschedparam (&tattr, &param);
 
     ret = session_obj_init();
     if (0 != ret) {
         AGM_LOGE("Session_obj_init failed with %d", ret);
-        goto exit;
+        goto cleanup_attr;
     }
     ret = gsl_cshm_init(0);
     if (ret == AR_EUNSUPPORTED) {
@@ -139,11 +152,27 @@ int agm_init()
     }
     agm_initialized = 1;
 
-    ret = pthread_create(&ats_thread, (const pthread_attr_t *) &tattr,
-                                           ats_init_thread, NULL);
-    if (ret)
-        AGM_LOGE(" ats init thread creation failed\n");
+    bool enable_ats_thread = true;
+    atomic_store(&ats_stop_requested, false);
+#ifdef AGM_USE_CUTILS
+    enable_ats_thread = property_get_bool("persist.vendor.audio.atsthread.enable", true);
+#endif
 
+    if (enable_ats_thread) {
+        ret = pthread_create(&ats_thread, (const pthread_attr_t *) &tattr,
+                                           ats_init_thread, NULL);
+        if (ret) {
+            AGM_LOGE("ats init thread creation failed");
+            ats_thread_started = false;
+        } else {
+            ats_thread_started = true;
+        }
+    } else {
+        AGM_LOGI("ats init is disabled");
+    }
+
+cleanup_attr:
+    (void)pthread_attr_destroy(&tattr);
 exit:
     return ret;
 }
@@ -153,6 +182,14 @@ int agm_deinit()
     int ret = 0;
     //close all sessions first
     if (agm_initialized) {
+        atomic_store(&ats_stop_requested, true); /* stop init retries */
+        if (ats_thread_started) {
+            /* Ensure ats_init_thread() has exited before tearing ATS down.
+             * This avoids ats_init()/ats_deinit() running concurrently.
+             */
+            (void)pthread_join(ats_thread, NULL);
+            ats_thread_started = false;
+        }
         AGM_LOGD("Deinitializing ATS...");
         ats_deinit();
 /*

--- a/service/src/agm.c
+++ b/service/src/agm.c
@@ -67,7 +67,7 @@
 static bool agm_initialized = 0;
 static bool ats_thread_started = false;
 //Stop init retries when AGM is deinitialized
-static atomic_bool ats_stop_requested = ATOMIC_VAR_INIT(false);
+static atomic_bool ats_stop_requested = false;
 static pthread_t ats_thread;
 static const int MAX_RETRIES = 120;
 

--- a/service/src/graph.c
+++ b/service/src/graph.c
@@ -26,38 +26,9 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
-** Changes from Qualcomm Innovation Center are provided under the following license:
-** Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved.
-**
-** Redistribution and use in source and binary forms, with or without
-** modification, are permitted (subject to the limitations in the
-** disclaimer below) provided that the following conditions are met:
-**
-**   * Redistributions of source code must retain the above copyright
-**     notice, this list of conditions and the following disclaimer.
-**
-**   * Redistributions in binary form must reproduce the above
-**     copyright notice, this list of conditions and the following
-**     disclaimer in the documentation and/or other materials provided
-**     with the distribution.
-**
-**   * Neither the name of Qualcomm Innovation Center, Inc. nor the names of its
-**     contributors may be used to endorse or promote products derived
-**     from this software without specific prior written permission.
-**
-** NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
-** GRANTED BY THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
-** HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-** WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-** MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-** IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-** ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-** DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
-** GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-** INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
-** IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
-** OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
-** IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * \copyright
+ *  Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ *  SPDX-License-Identifier: BSD-3-Clause
  */
 #define LOG_TAG "AGM: graph"
 
@@ -2205,7 +2176,7 @@ int graph_get_tckv_data_from_acdb(
     uint32_t *ptr = NULL;
     size_t query_payload_size = *payload_size;
     struct apm_module_param_data_t *param = (apm_module_param_data_t *)payload;
-    uint32_t *param_list;
+    uint8_t *param_list;
 
     if (!payload) {
         return -EINVAL;


### PR DESCRIPTION
Commits included : 

alsalib: fix session_mode type mismatch in agm_io_plugin 
plugins: add support for ALSA plugin 
plugins: enable AGM syslog flag and update installation folder 
plugins: test: Correct null check for compress 
agm: service: fix typecasting issues for GCC 14.2 
agm:ats: add property control and fix init thread races 
DBus:agm_server: fix memcpy against buf_size overflow
agm: avoid using ATOMIC_VAR_INIT for atomic_bool init