### PR TITLE
agm: implement start threshold logic

### DIFF
--- a/service/inc/private/agm/session_obj.h
+++ b/service/inc/private/agm/session_obj.h
@@ -100,6 +100,7 @@ struct session_obj {
     bool ec_ref_state;
     uint32_t rx_metadata_sz;
     uint32_t tx_metadata_sz;
+    size_t bytes_written;
     pthread_mutex_t lock;
     pthread_mutex_t cb_pool_lock;
 };

--- a/service/src/session_obj.c
+++ b/service/src/session_obj.c
@@ -1050,6 +1050,7 @@ static int session_prepare(struct session_obj *sess_obj)
                 goto done;
             } else {
                 sess_obj->state = SESSION_PREPARED;
+                sess_obj->bytes_written = 0;
             }
         }
     } else if(sess_obj->state != SESSION_STARTED) {
@@ -2520,6 +2521,29 @@ int session_obj_write(struct session_obj *sess_obj, void *buff, size_t *count)
     ret = graph_write(sess_obj->graph, &buffer, count);
     if (ret) {
         AGM_LOGE("Error:%d writing to graph\n", ret);
+        goto done;
+    }
+
+    /*
+     * Auto-start the session when start_threshold is configured and the
+     * session is in PREPARED state. Once the total bytes written reaches
+     * or exceeds start_threshold, AGM triggers session_start() internally
+     * so the client does not need to call agm_session_start() explicitly.
+     */
+    if (sess_obj->stream_config.start_threshold > 0 &&
+        sess_obj->state == SESSION_PREPARED) {
+        sess_obj->bytes_written += *count;
+        if (sess_obj->bytes_written >= sess_obj->stream_config.start_threshold) {
+            AGM_LOGD("start_threshold (%u bytes) reached after %zu bytes written,"
+                     " auto-starting session %d\n",
+                     sess_obj->stream_config.start_threshold,
+                     sess_obj->bytes_written, sess_obj->sess_id);
+            ret = session_start(sess_obj);
+            if (ret)
+                AGM_LOGE("Error:%d auto-starting session %d on threshold\n",
+                         ret, sess_obj->sess_id);
+            sess_obj->bytes_written = 0;
+        }
     }
 
 done:


### PR DESCRIPTION
Start threshold is ALSA standard mechanism to trigger start the playback automatically after client has written sufficient data exceeding the start threshold. Currently, AGM does not have start threhold implemented though it alreay stores start threhold value. Tinyplay does not call pcm_start() as it expects underlying sound card supports start threshold. Hence, one would not be able to get tinyplay working without this change. At the same time, skip start threshold implementation for non-tunnel mode as this mode is meant for decoding/encoding offloading to AudioReach engine. Additional patch can be submitted if start threshold is found to be useful for non-tunnel mode.

CRs-Fixed: 4564989