### PR TITLE
Switch pre-merge workflow to pull_request and add LAVA trigger flow

### DIFF
--- a/.github/workflows/pre_merge_build.yml
+++ b/.github/workflows/pre_merge_build.yml
@@ -1,13 +1,13 @@
 ---
 name: pre_merge_build
+
 run-name: ${{ github.event.pull_request.number && 'Pre Merge Build PR:' || 'Pre Merge Build:' }}${{ github.event.pull_request.number || github.run_number }}
 
 on:
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
-    branches:
-      - master
+    branches: [master]
     paths-ignore:
       - '.github/**'
 
@@ -31,7 +31,7 @@ jobs:
       pr_repo: ${{ github.event.pull_request.head.repo.full_name }}
 
   process_image:
-    needs: [ load_parameters, build ]
+    needs: [load_parameters, build]
     uses: Audioreach/audioreach-workflows/.github/workflows/process_image.yml@master
     secrets: inherit
     with:
@@ -49,42 +49,26 @@ jobs:
       - id: filter
         shell: bash
         run: |
-            MATRIX='${{ needs.load_parameters.outputs.build_matrix }}'
+          MATRIX='${{ needs.load_parameters.outputs.build_matrix }}'
 
-            echo "RAW build_matrix:"
-            echo "$MATRIX"
+          echo "$MATRIX" | jq . >/dev/null
 
-            echo "Validating JSON..."
-            echo "$MATRIX" | jq . >/dev/null
+          FILTERED=$(echo "$MATRIX" | jq -c '
+            if type == "object" then
+              to_entries
+              | map(select(.value.testing_enabled == true))
+              | from_entries
+            elif type == "array" then
+              map(select(.testing_enabled == true))
+            else
+              error("Unsupported JSON type")
+            end
+          ')
 
-            # Supports:
-            # 1) object keyed by name: { "name": {testing_enabled:true}, ... }
-            # 2) array of entries: [ {Testing_enabled:true,...}, ... ]  (will convert to include list)
-            FILTERED=$(
-              echo "$MATRIX" | jq -c '
-                if type == "object" then
-                  to_entries
-                  | map(select(.value.testing_enabled == true))
-                  | from_entries
-                elif type == "array" then
-                  map(select(.testing_enabled == true))  # <-- Just return the array
-                else
-                  error("Unsupported build_matrix JSON type: " + (type|tostring))
-                end
-              '
-            )
+          echo "$FILTERED" > test_matrix.json
+          echo "test_matrix=$FILTERED" >> "$GITHUB_OUTPUT"
 
-            echo "Filtered matrix (pretty):"
-            echo "$FILTERED" | jq .
-
-            echo "test_matrix=$FILTERED" >> "$GITHUB_OUTPUT"
-
-  trigger_lava:
-    needs: [ process_image, filter_test_matrix ]
-    permissions:
-      checks: write
-      pull-requests: write
-    uses: Audioreach/audioreach-workflows/.github/workflows/test.yml@master
-    secrets: inherit
-    with:
-      build_matrix: ${{ needs.filter_test_matrix.outputs.test_matrix }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: test-matrix
+          path: test_matrix.json

--- a/.github/workflows/trigger_lava_on_success.yml
+++ b/.github/workflows/trigger_lava_on_success.yml
@@ -1,0 +1,95 @@
+name: trigger_lava_on_success
+
+on:
+  workflow_run:
+    workflows: ["pre_merge_build"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+  actions: read
+  checks: write
+  pull-requests: write
+
+jobs:
+  prepare_matrix:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    outputs:
+      test_matrix: ${{ steps.matrix.outputs.test_matrix }}
+      build_urls: ${{ steps.read_url.outputs.build_urls }}
+
+    steps:
+      - name: Download test matrix artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: test-matrix
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download presigned URL artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: presigned_url_*.txt
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: presigned_urls
+          merge-multiple: true
+
+      - name: Read presigned URLs
+        id: read_url
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs')
+            const path = require('path')
+
+            const baseDir = 'presigned_urls'
+            const entries = fs.readdirSync(baseDir)
+
+            console.log('Entries:', entries)
+
+            if (entries.length === 0) {
+              throw new Error('No presigned URL files found')
+            }
+
+            const urls = {}
+
+            for (const entry of entries) {
+              const fullPath = path.join(baseDir, entry)
+              if (fs.statSync(fullPath).isFile()) {
+                const content = fs.readFileSync(fullPath, 'utf8').trim()
+                urls[entry] = content
+                console.log(`Loaded ${entry}: ${content}`)
+              }
+            }
+
+            if (Object.keys(urls).length === 0) {
+              throw new Error('No valid presigned URL files found')
+            }
+
+            core.setOutput('build_urls', JSON.stringify(urls))
+
+      - name: Re-upload presigned URL artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: presigned_urls
+          path: presigned_urls
+
+      - name: Read matrix JSON
+        id: matrix
+        shell: bash
+        run: |
+          test -f test_matrix.json
+          MATRIX=$(cat test_matrix.json)
+          echo "test_matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+
+  trigger_lava:
+    needs: prepare_matrix
+    uses: Audioreach/audioreach-workflows/.github/workflows/test.yml@master
+    secrets: inherit
+    with:
+      build_matrix: ${{ needs.prepare_matrix.outputs.test_matrix }}
+      build_urls: ${{ needs.prepare_matrix.outputs.build_urls }}
+


### PR DESCRIPTION
Switch trigger from pull_request_target to pull_request to improve security and align with standard GitHub Actions practices. Normalize YAML formatting and dependencies for clarity. [1]

Simplify test matrix filtering by refining jq logic, validating JSON, and supporting both object and array formats. Persist the filtered matrix to test_matrix.json and upload it as an artifact.

Replace inline LAVA trigger with trigger_lava_on_success workflow, which runs after a successful build, retrieves artifacts, extracts the build URL, and invokes LAVA tests with the prepared matrix.

[1] AudioReach/audioreach-workflows#73