### PR TITLE
audioreach-graphmgr: build AGM tinycompress plugin

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -80,6 +80,13 @@ AC_SUBST(SPF_CFLAGS)
 PKG_CHECK_MODULES([KVH2XML], [kvh2xml])
 AC_SUBST([KVH2XML_CFLAGS])
 
+# tinycompress is not available on all platforms (e.g. Raspberry Pi), so
+# probe for it optionally instead of failing configure when it is absent.
+PKG_CHECK_MODULES([TINYCOMPRESS], [tinycompress], [have_tinycompress=yes], [have_tinycompress=no])
+AM_CONDITIONAL([HAVE_TINYCOMPRESS], [test "x${have_tinycompress}" = "xyes"])
+AC_SUBST([TINYCOMPRESS_CFLAGS])
+AC_SUBST([TINYCOMPRESS_LIBS])
+
 # Check dependency only if with_no_ipc is not set
 if (test "x${with_no_ipc}" = "xno"); then
 PKG_CHECK_MODULES(DBUS, [ dbus-1 >= 1.4.12 ], dummy=yes,

--- a/plugins/tinyalsa/Makefile.am
+++ b/plugins/tinyalsa/Makefile.am
@@ -30,19 +30,23 @@ libagm_pcm_plugin_la_LDFLAGS += -L$(top_builddir)/ipc/DBus/agm_client/.libs
 libagm_pcm_plugin_la_LIBADD += -lagmclient
 endif
 
-#lib_LTLIBRARIES      += libtinycompress_module_agm.la
-#libtinycompress_module_agm_la_SOURCES = src/agm_compress_plugin.c
-#libtinycompress_module_agm_la_CFLAGS  = $(AM_CFLAGS)
-#libtinycompress_module_agm_la_LDFLAGS = -shared -version-number @LT_VERSION_NUMBER@ -L$(top_builddir)/snd_parser/.libs
-#libtinycompress_module_agm_la_LIBADD  = -ltinyalsa -ltinycompress -lpthread -lsndcardparser
-#if AGM_NO_IPC
-#libtinycompress_module_agm_la_CFLAGS += -DAGM_NO_IPC
-#libtinycompress_module_agm_la_LDFLAGS += -L$(top_builddir)/service/.libs
-#libtinycompress_module_agm_la_LIBADD += -lagm
-#else
-#libtinycompress_module_agm_la_LDFLAGS += -L$(top_builddir)/ipc/DBus/agm_client/.libs
-#libtinycompress_module_agm_la_LIBADD += -lagmclient
-#endif
+tinycompressplugindir = $(libdir)/tinycompress-lib
+
+if HAVE_TINYCOMPRESS
+tinycompressplugin_LTLIBRARIES = libtinycompress_module_agm.la
+libtinycompress_module_agm_la_SOURCES = src/agm_compress_plugin.c
+libtinycompress_module_agm_la_CFLAGS  = $(AM_CFLAGS) @TINYCOMPRESS_CFLAGS@
+libtinycompress_module_agm_la_LDFLAGS = -shared -version-number @LT_VERSION_NUMBER@ -L$(top_builddir)/snd_parser/.libs
+libtinycompress_module_agm_la_LIBADD  = -ltinyalsa @TINYCOMPRESS_LIBS@ -lpthread -lsndcardparser
+if AGM_NO_IPC
+libtinycompress_module_agm_la_CFLAGS += -DAGM_NO_IPC
+libtinycompress_module_agm_la_LDFLAGS += -L$(top_builddir)/service/.libs
+libtinycompress_module_agm_la_LIBADD += -lagm
+else
+libtinycompress_module_agm_la_LDFLAGS += -L$(top_builddir)/ipc/DBus/agm_client/.libs
+libtinycompress_module_agm_la_LIBADD += -lagmclient
+endif
+endif
 
 lib_LTLIBRARIES      += libagm_mixer_plugin.la
 libagm_mixer_plugin_la_SOURCES = src/agm_mixer_plugin.c


### PR DESCRIPTION
Enable libtinycompress_module_agm build.
Link plugin against AGM, tinycompress, and parser libs. 
Provide tinycompress backend for compressed offload.

CRs-Fixed: 4648274