### PR TITLE
agm: service: Fix dead CLOSED state check in graph_stop

### DIFF
--- a/service/src/graph.c
+++ b/service/src/graph.c
@@ -909,7 +909,7 @@ int graph_stop(struct graph_obj *graph_obj,
 
     pthread_mutex_lock(&graph_obj->lock);
     AGM_LOGD("entry graph_handle %p\n", graph_obj->graph_handle);
-    if ((graph_obj->state & (CLOSED))) {
+    if (graph_obj->state == CLOSED) {
        AGM_LOGE("graph object is not in correct state, current state %d\n",
                     graph_obj->state);
        ret = -EINVAL;


### PR DESCRIPTION
CLOSED is defined as 0x0 in graph_state_t. Using a bitwise AND to test for it (state & CLOSED) always evaluates to zero, making the guard in graph_stop() permanently dead code. A closed graph could therefore proceed past the check and attempt a stop on an invalid handle.

Replace the bitwise AND with an equality check to correctly detect the CLOSED state.

CRs-Fixed: 4576098