### PR TITLE
DBus:agm_server: Initialize num_aif_info before AGM AIF query

### DIFF
--- a/ipc/DBus/agm_server/src/agm_server_wrapper_dbus.cpp
+++ b/ipc/DBus/agm_server/src/agm_server_wrapper_dbus.cpp
@@ -1459,7 +1459,7 @@ static void ipc_agm_get_aif_info_list(DBusConnection *conn,
     DBusMessageIter arg_i;
     DBusMessageIter r_arg, array_i, struct_i;
     agm_module_dbus_data *mdata = (agm_module_dbus_data *)userdata;
-    size_t num_aif_info;
+    size_t num_aif_info = 0;
     struct aif_info *aifinfo = NULL;
     char *name;
     int i = 0;


### PR DESCRIPTION
Initialize num_aif_info to 0 in ipc_agm_get_aif_info_list() to prevent passing uninitialized/garbage values to the AGM API.

CRs-Fixed: 4605734