### PR TITLE
DBus:agm_server: Fix heap corruption in ipc_agm_session_write

### DIFF
--- a/ipc/DBus/agm_server/src/agm_server_wrapper_dbus.cpp
+++ b/ipc/DBus/agm_server/src/agm_server_wrapper_dbus.cpp
@@ -2068,21 +2068,31 @@ static void ipc_agm_session_set_config(DBusConnection *conn,
                             "agm_session_set_config failed.");
         return;
     }
+    uint32_t total_buf_size = buffer_config.count * (uint32_t)buffer_config.size;
+    if (buffer_config.count == 0 || buffer_config.size == 0 ||
+        total_buf_size / buffer_config.count != (uint32_t)buffer_config.size) {
+        AGM_LOGE("set_config session %u invalid buffer params count=%u size=%u",
+                 ses_data->session_id, buffer_config.count, buffer_config.size);
+        agm_dbus_send_error(mdata->conn, msg, DBUS_ERROR_FAILED,
+                            "set_config failed: invalid or overflowing buffer params");
+        return;
+    }
     pthread_mutex_lock(&ses_data->lock);
-    if (ses_data->buf == NULL || ses_data->buf_size != buffer_config.size) {
+    if (ses_data->buf == NULL || ses_data->buf_size != total_buf_size) {
         if (ses_data->buf != NULL) {
             free(ses_data->buf);
             ses_data->buf = NULL;
         }
-        ses_data->buf = (void*) calloc(1, buffer_config.size);
+        ses_data->buf = (void*) calloc(1, total_buf_size);
         if (ses_data->buf == NULL) {
-            AGM_LOGE("Cannot allocate memory for buffer\n");
+            AGM_LOGE("Cannot allocate memory for buffer session %u total=%u",
+                     ses_data->session_id, total_buf_size);
             pthread_mutex_unlock(&ses_data->lock);
             agm_dbus_send_error(mdata->conn, msg, DBUS_ERROR_FAILED,
                                 "Cannot allocate memory for buffer");
             return;
         }
-        ses_data->buf_size = buffer_config.size;
+        ses_data->buf_size = total_buf_size;
     }
     pthread_mutex_unlock(&ses_data->lock);
 
@@ -2159,12 +2169,20 @@ static void ipc_agm_session_write(DBusConnection *conn,
     dbus_message_iter_get_fixed_array(&array_i, addr_value, &n_elements);
 
     pthread_mutex_lock(&ses_data->lock);
-    ses_data->buf_size = buf_size;
     if (ses_data->thread_state != SES_THREAD_IDLE) {
         pthread_mutex_unlock(&ses_data->lock);
         agm_dbus_send_error(mdata->conn, msg, DBUS_ERROR_FAILED, "write via async failed");
         return;
     }
+    if (n_elements < 0 || (uint32_t)n_elements > ses_data->buf_size) {
+        pthread_mutex_unlock(&ses_data->lock);
+        AGM_LOGE("session %u write overflow: n_elements=%d > allocated buf_size=%u",
+                 ses_data->session_id, n_elements, ses_data->buf_size);
+        agm_dbus_send_error(mdata->conn, msg, DBUS_ERROR_FAILED,
+                            "write failed: data size exceeds allocated buffer");
+        return;
+    }
+    ses_data->buf_size = buf_size;
     memcpy(ses_data->buf, value, n_elements);
     ses_data->thread_state = SES_THREAD_WRITE_QUEUED;
     snprintf(ses_data->eventType, sizeof("Signal"), "%s", "Signal");


### PR DESCRIPTION
The async DBus write path allocated the session buffer to buffer_config.size (one buffer, e.g. 4096 bytes) in ipc_agm_session_set_config, but the client's agm_session_write sends count * size bytes per call (e.g. 4 * 4096 = 16384 bytes). The subsequent memcpy in ipc_agm_session_write copied up to n_elements bytes with no bounds check against the allocated size, writing 12 KB past the end of the heap chunk on every write call. glibc detected the overwritten chunk metadata on the next consolidation and aborted with "corrupted size vs. prev_size while consolidating".

Fix ipc_agm_session_set_config to allocate count * size bytes so the buffer covers the full write payload the client will send. Guard ipc_agm_session_write against n_elements exceeding the allocated buf_size and return a DBus error instead of corrupting the heap.

CRs-Fixed: 4603328