### PR TITLE
DBus:agm_server: Fix self-referential cast in agm_free_session

### DIFF
--- a/ipc/DBus/agm_server/src/agm_server_wrapper_dbus.cpp
+++ b/ipc/DBus/agm_server/src/agm_server_wrapper_dbus.cpp
@@ -443,7 +443,7 @@ static DBusHandlerResult disconnection_filter_cb(DBusConnection *conn,
 }
 
 void agm_free_session(gpointer c_data) {
-    agm_session_data *data = (agm_session_data *)data;
+    agm_session_data *data = (agm_session_data *)c_data;
 
     if(data == NULL)
         return;


### PR DESCRIPTION
Cast c_data argument instead of the uninitialised local pointer, avoiding undefined behaviour on every dereference in this function.

CRs-Fixed: 4609557