### PR TITLE
agm: fallback to default scheduling on SCHED_FIFO thread failure

### DIFF
--- a/service/src/agm.c
+++ b/service/src/agm.c
@@ -162,6 +162,10 @@ int agm_init()
         ret = pthread_create(&ats_thread, (const pthread_attr_t *) &tattr,
                                            ats_init_thread, NULL);
         if (ret) {
+            AGM_LOGI("ats thread: SCHED_FIFO failed (err=%d), retrying with default scheduling", ret);
+            ret = pthread_create(&ats_thread, NULL, ats_init_thread, NULL);
+        }
+        if (ret) {
             AGM_LOGE("ats init thread creation failed");
             ats_thread_started = false;
         } else {


### PR DESCRIPTION
On Linux user sessions (e.g. PipeWire running as a non-root user service on Debian), pthread_create with SCHED_FIFO attributes fails with EPERM because CAP_SYS_NICE is not available. This caused agm_init() to mark the ATS thread as not started and return an error, which prevented the first PAL module from initializing.

Fix by retrying pthread_create with NULL attributes (default scheduling) when the real-time scheduling attempt fails. Add an AGM_LOGI to make the fallback visible in logs. This ensures ATS initialization succeeds in environments without real-time scheduling privileges.
