### PR TITLE
agm: Fix __builtin_usubl_overflow type mismatch on ARM32

### DIFF
--- a/plugins/tinyalsa/src/agm_pcm_plugin.c
+++ b/plugins/tinyalsa/src/agm_pcm_plugin.c
@@ -346,7 +346,7 @@ static int agm_pcm_plugin_update_hw_ptr(struct agm_pcm_priv *priv)
                                          priv->pos_buf->wall_clk_lsw);
             // Compute delta only if diff is greater than zero
             if (dsp_wall_clk > cached_wall_clk) {
-                __builtin_usubl_overflow(dsp_wall_clk,cached_wall_clk,&sub_res);
+                __builtin_sub_overflow(dsp_wall_clk, cached_wall_clk, &sub_res);
                 delta_wall_clk_us = (int64_t)sub_res;
             }
         }


### PR DESCRIPTION
On ARM32 (ILP32), unsigned long is 32-bit while uint64_t is unsigned long long (64-bit). Passing &sub_res (uint64_t *) to __builtin_usubl_overflow, which expects unsigned long *, is an incompatible pointer type error with GCC 15.2 targeting cortexa7t2hf-neon-vfpv4.

Replace __builtin_usubl_overflow with __builtin_usubll_overflow to match the uint64_t type of sub_res on all ABIs.