### PR TITLE
agm-pcm: guard poll path and validate NOIRQ mmap buffers

### DIFF
--- a/plugins/tinyalsa/src/agm_pcm_plugin.c
+++ b/plugins/tinyalsa/src/agm_pcm_plugin.c
@@ -769,6 +769,24 @@ static int agm_pcm_poll(struct pcm_plugin *plugin, struct pollfd *pfd,
     int ret = 0;
     uint32_t period_to_msec = period_size / (priv->media_config->rate / 1000);
 
+    /* Non-NOIRQ path does not use pos_buf. */
+    if (!(plugin->mode & PCM_NOIRQ)) {
+        if (timeout > 0)
+            usleep(timeout * 1000);
+        if (plugin->mode & PCM_IN) {
+            pfd->revents = POLLIN | POLLOUT;
+            return POLLIN;
+        }
+        pfd->revents = POLLOUT;
+        return POLLOUT;
+    }
+
+    if (!priv->mmap_status || !priv->pos_buf) {
+        pfd->revents = POLLERR;
+        errno = ENODEV;
+        return -ENODEV;
+    }
+
     avail = agm_pcm_get_avail(plugin);
 
     if(priv->mmap_buf_tout &&


### PR DESCRIPTION
Signed-off-by: Mark Adams <markadam@qti.qualcomm.com>

This patch hardens agm_pcm_poll() by separating NOIRQ and non-NOIRQ behavior and adding explicit mmap buffer checks.

Changes:
- For non-NOIRQ mode, skip pos_buf usage and return readiness based on stream direction after honoring a positive timeout.
- For NOIRQ mode, require both mmap_status and pos_buf before calling agm_pcm_get_avail().
- If required NOIRQ mmap state is missing, return POLLERR with ENODEV.

Why:
The non-NOIRQ path does not rely on pos_buf. The new guards prevent invalid buffer access of pos_buf and make poll behavior mode-correct.